### PR TITLE
fix: 뉴스 즉시 표시 + 고래 알림 개선

### DIFF
--- a/src/api/news.js
+++ b/src/api/news.js
@@ -84,7 +84,7 @@ function parseRssItems(items, category, sourceName) {
 // 주의: 이 함수는 카테고리당 최대 1회 호출하도록 설계됨
 async function fetchViaRss2json(rssUrl, category, sourceName) {
   const url = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(rssUrl)}&count=20`;
-  const res  = await fetch(url, { signal: AbortSignal.timeout(6000) });
+  const res  = await fetch(url, { signal: AbortSignal.timeout(4000) });
   if (!res.ok) throw new Error(`rss2json ${res.status}`);
   const data = await res.json();
   if (data.status !== 'ok' || !data.items?.length) throw new Error('rss2json empty');
@@ -95,7 +95,7 @@ async function fetchViaRss2json(rssUrl, category, sourceName) {
 // fallback 전용 — 가능하면 사용하지 않음
 async function fetchViaAllorigins(rssUrl, category, sourceName) {
   const url  = `https://api.allorigins.win/get?url=${encodeURIComponent(rssUrl)}`;
-  const res  = await fetch(url, { signal: AbortSignal.timeout(7000) });
+  const res  = await fetch(url, { signal: AbortSignal.timeout(5000) });
   if (!res.ok) throw new Error(`allorigins ${res.status}`);
   const json = await res.json();
   const text = json.contents ?? '';
@@ -264,35 +264,20 @@ async function fetchUsNews() {
   return items;
 }
 
-// [국장] Google News 통합 쿼리 1회 + 한경/매경 RSS 순차 호출
-// 핵심 전략: rss2json 호출을 기존 4회 → 1회로 줄임
-// (한경/매경은 CORS 문제 없으면 직접, 아니면 allorigins fallback)
+// [국장] Google News 통합 쿼리 1회 — allorigins 의존 제거로 속도 개선
+// 한경/매경 allorigins는 4-7초 소요라 제거, Google News로 통합
 async function fetchKrNews() {
   const cached = cacheGet('kr');
   if (cached?.fresh) return cached.data;
 
-  // Google News 통합 쿼리 — rss2json 1회
+  // Google News 통합 쿼리 — rss2json 1회 (가장 빠름)
   const googleItems = await fetchRSS(
     'https://news.google.com/rss/search?q=%EC%BD%94%EC%8A%A4%ED%94%BC+%EC%BD%94%EC%8A%A4%EB%8B%A5+%EC%A6%9D%EC%8B%9C+%EC%A3%BC%EC%8B%9D+%EC%97%85%EC%A2%85+%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90&hl=ko&gl=KR&ceid=KR:ko',
     'kr',
     '구글뉴스',
   );
 
-  // 한국경제 직접 RSS — allorigins로 호출 (rss2json 대신)
-  // 국장은 CryptoCompare 같은 전용 API가 없어 RSS 불가피
-  // 단, 카테고리당 최대 2개 RSS 소스만 허용
-  const [hankyungItems, mkItems] = await Promise.allSettled([
-    fetchViaAllorigins('https://www.hankyung.com/feed/stock', 'kr', '한국경제'),
-    fetchViaAllorigins('https://www.mk.co.kr/rss/30000001/', 'kr', '매일경제'),
-  ]);
-
-  const all = [
-    ...googleItems,
-    ...(hankyungItems.status === 'fulfilled' ? hankyungItems.value : []),
-    ...(mkItems.status       === 'fulfilled' ? mkItems.value       : []),
-  ];
-
-  const items = dedup(all.filter(isFinancialNews))
+  const items = dedup(googleItems.filter(isFinancialNews))
     .sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate))
     .slice(0, 30);
 
@@ -358,4 +343,18 @@ export function invalidateNewsCache() {
   ['all','coin','us','kr'].forEach(k => {
     try { localStorage.removeItem(`news_${k}`); } catch {}
   });
+}
+
+// React Query initialData용 — 동기 로컬스토리지 즉시 반환 (stale 포함)
+// 앱 첫 로드 시 캐시 데이터를 즉각 표시하고 백그라운드 갱신
+export function getInitialNewsData(key = 'all') {
+  return cacheGet(key)?.data ?? undefined;
+}
+
+export function getInitialNewsTimestamp(key = 'all') {
+  try {
+    const raw = localStorage.getItem(`news_${key}`);
+    if (!raw) return 0;
+    return JSON.parse(raw).ts ?? 0;
+  } catch { return 0; }
 }

--- a/src/api/whale.js
+++ b/src/api/whale.js
@@ -118,93 +118,102 @@ export function resetWhaleSnapshot() {
 // 단일 체결 기준 억 단위 이상 → 고래 의심
 // ─────────────────────────────────────────────────────────────
 
-let whaleWs      = null;
-let whaleHandler = null;
+let whaleWs        = null;
+let whaleHandler   = null;
+let whaleSymbols   = null;
+let reconnectTimer = null;
+let destroyed      = false;
 
-/**
- * subscribeUpbitWhaleTrades(symbols, onEvent)
- *
- * @param {string[]} symbols  - ['BTC','ETH','XRP']
- * @param {Function} onEvent  - ({ symbol, type: 'whale_trade', price, volume, tradeAmt, message })
- *
- * 단일 체결에서 tradeAmt = price × volume (원화)
- * 임계값: 5억 원 이상 단일 체결 → 고래 의심
- */
-export function subscribeUpbitWhaleTrades(symbols, onEvent) {
-  // 기존 연결 해제
-  if (whaleWs) {
-    whaleWs.close();
-    whaleWs = null;
-  }
+// 원화 금액 포맷
+function fmtKrw(n) {
+  if (n >= 1e12) return `${(n / 1e12).toFixed(1)}조`;
+  if (n >= 1e8)  return `${(n / 1e8).toFixed(1)}억`;
+  if (n >= 1e4)  return `${(n / 1e4).toFixed(0)}만`;
+  return n.toLocaleString('ko-KR');
+}
 
-  const THRESHOLD_KRW = 500_000_000; // 5억 원
-  const markets = symbols.map(s => `KRW-${s}`);
+function connectWs() {
+  if (destroyed || !whaleSymbols || !whaleHandler) return;
+
+  const THRESHOLD_KRW = 100_000_000; // 1억 원 (BTC 1개 기준)
+  const HIGH_KRW      = 500_000_000; // 5억 원
+  const markets = whaleSymbols.map(s => `KRW-${s}`);
 
   try {
-    whaleWs = new WebSocket('wss://api.upbit.com/websocket/v1');
-    whaleHandler = onEvent;
+    const ws = new WebSocket('wss://api.upbit.com/websocket/v1');
+    whaleWs = ws;
 
-    whaleWs.onopen = () => {
-      // Upbit WebSocket 구독 요청 형식
-      const payload = JSON.stringify([
-        { ticket: 'whale-alert' },
-        { type: 'trade', codes: markets, isOnlyRealtime: true },
+    ws.onopen = () => {
+      ws.send(JSON.stringify([
+        { ticket: `whale-${Date.now()}` },
+        { type: 'trade', codes: markets },
         { format: 'DEFAULT' },
-      ]);
-      whaleWs.send(payload);
+      ]));
+      // 연결 성공 콜백 (연결 상태 알림용 특수 이벤트)
+      whaleHandler?.({ _connected: true });
     };
 
-    whaleWs.onmessage = async (evt) => {
-      // Upbit은 ArrayBuffer 또는 Blob으로 전송
+    ws.onmessage = async (evt) => {
       let text;
-      if (evt.data instanceof Blob) {
-        text = await evt.data.text();
-      } else if (evt.data instanceof ArrayBuffer) {
-        text = new TextDecoder().decode(evt.data);
-      } else {
-        text = evt.data;
-      }
+      if (evt.data instanceof Blob)        text = await evt.data.text();
+      else if (evt.data instanceof ArrayBuffer) text = new TextDecoder().decode(evt.data);
+      else text = evt.data;
 
       try {
         const data = JSON.parse(text);
         if (data.type !== 'trade') return;
 
-        const price    = data.trade_price;
-        const volume   = data.trade_volume;
+        const price    = data.trade_price ?? 0;
+        const volume   = data.trade_volume ?? 0;
         const tradeAmt = price * volume;
-
         if (tradeAmt < THRESHOLD_KRW) return;
 
-        const symbol  = (data.code || '').replace('KRW-', '');
-        const side    = data.ask_bid === 'ASK' ? '매도' : '매수';
-        const amtStr  = tradeAmt >= 1_000_000_000
-          ? `${(tradeAmt / 1_000_000_000).toFixed(1)}십억`
-          : `${(tradeAmt / 100_000_000).toFixed(1)}억`;
+        const symbol = (data.code || '').replace('KRW-', '');
+        const side   = data.ask_bid === 'ASK' ? '매도' : '매수';
 
         whaleHandler?.({
           symbol,
-          type:     'whale_trade',
-          severity: tradeAmt >= 2_000_000_000 ? 'high' : 'medium',
+          type:      'whale_trade',
+          severity:  tradeAmt >= HIGH_KRW ? 'high' : 'medium',
           price,
           volume,
           tradeAmt,
           side,
-          message:  `🐋 ${symbol} 고래 ${side} ${amtStr}원 (${volume.toFixed(4)})`,
+          message:   `${symbol} ${side} ${fmtKrw(tradeAmt)}원 (${volume % 1 === 0 ? volume : volume.toFixed(4)})`,
           timestamp: Date.now(),
         });
       } catch {}
     };
 
-    whaleWs.onerror = (err) => {
-      console.warn('[whale-ws] 오류:', err.message);
-    };
+    ws.onerror = () => {};
 
-    whaleWs.onclose = () => {
+    ws.onclose = () => {
       whaleWs = null;
+      if (!destroyed) {
+        // 5초 후 자동 재연결
+        reconnectTimer = setTimeout(connectWs, 5000);
+      }
     };
-  } catch (err) {
-    console.warn('[whale-ws] WebSocket 연결 실패:', err.message);
+  } catch {
+    if (!destroyed) reconnectTimer = setTimeout(connectWs, 5000);
   }
+}
+
+/**
+ * subscribeUpbitWhaleTrades(symbols, onEvent)
+ * @param {string[]} symbols - ['BTC','ETH',...]
+ * @param {Function} onEvent - 이벤트 수신 콜백
+ *   onEvent({ _connected: true }) → 연결 성공 알림
+ *   onEvent({ symbol, type, severity, tradeAmt, side, message, timestamp })
+ */
+export function subscribeUpbitWhaleTrades(symbols, onEvent) {
+  destroyed      = false;
+  whaleSymbols   = symbols;
+  whaleHandler   = onEvent;
+
+  if (whaleWs) { try { whaleWs.close(); } catch {} whaleWs = null; }
+  clearTimeout(reconnectTimer);
+  connectWs();
 }
 
 /**
@@ -212,9 +221,9 @@ export function subscribeUpbitWhaleTrades(symbols, onEvent) {
  * WebSocket 연결 해제 — 컴포넌트 언마운트 시 호출
  */
 export function unsubscribeUpbitWhaleTrades() {
-  if (whaleWs) {
-    whaleWs.close();
-    whaleWs     = null;
-    whaleHandler = null;
-  }
+  destroyed    = true;
+  whaleHandler = null;
+  whaleSymbols = null;
+  clearTimeout(reconnectTimer);
+  if (whaleWs) { try { whaleWs.close(); } catch {} whaleWs = null; }
 }

--- a/src/components/WhalePanel.jsx
+++ b/src/components/WhalePanel.jsx
@@ -1,6 +1,6 @@
 // 고래 알림 패널 — Upbit WebSocket 실시간 대량 체결 감지
-// 5억원 이상 단일 체결 → 고래 의심 알림
-import { useState, useEffect, useRef } from 'react';
+// 1억원 이상 단일 체결 → 고래 의심 알림, 5억원+ → HIGH
+import { useState, useEffect } from 'react';
 import { subscribeUpbitWhaleTrades, unsubscribeUpbitWhaleTrades } from '../api/whale';
 
 const MAX_EVENTS = 20;
@@ -58,30 +58,21 @@ const WATCH_SYMBOLS = [
 export default function WhalePanel({ isVisible = true }) {
   const [events,    setEvents]    = useState([]);
   const [connected, setConnected] = useState(false);
-  const [error,     setError]     = useState(false);
-  const eventsRef = useRef(events);
-  eventsRef.current = events;
 
   useEffect(() => {
     if (!isVisible) return;
 
-    setError(false);
-    // 약간 지연 후 연결 (앱 로드 시 부하 분산)
-    const t = setTimeout(() => {
-      try {
-        subscribeUpbitWhaleTrades(WATCH_SYMBOLS, (evt) => {
-          setConnected(true);
-          setEvents(prev => [evt, ...prev].slice(0, MAX_EVENTS));
-        });
-        // 연결 확인 (3초 후 소켓이 살아있으면 connected)
-        setTimeout(() => setConnected(true), 3000);
-      } catch {
-        setError(true);
+    setConnected(false);
+    subscribeUpbitWhaleTrades(WATCH_SYMBOLS, (evt) => {
+      if (evt._connected) {
+        setConnected(true);
+        return;
       }
-    }, 1500);
+      setConnected(true);
+      setEvents(prev => [evt, ...prev].slice(0, MAX_EVENTS));
+    });
 
     return () => {
-      clearTimeout(t);
       unsubscribeUpbitWhaleTrades();
       setConnected(false);
     };
@@ -103,25 +94,22 @@ export default function WhalePanel({ isVisible = true }) {
 
       {/* 이벤트 목록 */}
       <div className="max-h-[280px] overflow-y-auto">
-        {error && (
-          <div className="px-4 py-6 text-center text-[12px] text-[#B0B8C1]">
-            WebSocket 연결 실패. 새로고침해주세요.
-          </div>
-        )}
-        {!error && events.length === 0 && (
+        {events.length === 0 && (
           <div className="px-4 py-6 text-center">
-            <div className="text-[13px] text-[#B0B8C1] mb-1">5억원 이상 단일 체결 감지 중...</div>
+            <div className="text-[13px] text-[#B0B8C1] mb-1">
+              {connected ? '1억원 이상 단일 체결 감지 중...' : 'Upbit 연결 중...'}
+            </div>
             <div className="text-[11px] text-[#C9CDD2]">대량 매매 발생 시 즉시 표시됩니다</div>
           </div>
         )}
-        {!error && events.map((evt, i) => (
+        {events.map((evt, i) => (
           <EventRow key={`${evt.symbol}-${evt.timestamp}-${i}`} event={evt} />
         ))}
       </div>
 
       {/* 안내 */}
       <div className="px-4 py-2 border-t border-[#F2F4F6] bg-[#FAFBFC]">
-        <span className="text-[10px] text-[#C9CDD2]">Upbit 5억원+ 단일 체결 기준 · 거래소 입금은 매도 압력 신호</span>
+        <span className="text-[10px] text-[#C9CDD2]">Upbit 1억원+ 단일 체결 기준 · 5억원+ 시 HIGH 표시</span>
       </div>
     </div>
   );

--- a/src/hooks/useNewsQuery.js
+++ b/src/hooks/useNewsQuery.js
@@ -1,7 +1,11 @@
-// 뉴스 React Query 훅 — 전역 캐시로 중복 호출 차단
-// staleTime 5분: 탭 전환, 리렌더, 윈도우 포커스에도 API 재호출 없음
+// 뉴스 React Query 훅 — 전역 캐시 + 즉시 표시 패턴
+// initialData: 로컬스토리지 캐시를 즉시 표시 → "불러오는중" 제거
+// initialDataUpdatedAt: React Query가 staleTime 기준으로 백그라운드 갱신 여부 판단
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { fetchAllNews, fetchNewsByCategory, invalidateNewsCache } from '../api/news';
+import {
+  fetchAllNews, fetchNewsByCategory, invalidateNewsCache,
+  getInitialNewsData, getInitialNewsTimestamp,
+} from '../api/news';
 
 export const newsKeys = {
   all:      ['news', 'all'],
@@ -9,43 +13,49 @@ export const newsKeys = {
 };
 
 const NEWS_OPTIONS = {
-  staleTime:           5 * 60 * 1000,  // 5분 신선
-  gcTime:              15 * 60 * 1000, // 15분 후 메모리 정리
-  retry:               2,
-  retryDelay:          1500,
-  refetchOnWindowFocus: false,          // 탭 전환 시 재요청 방지
+  staleTime:            5 * 60 * 1000,  // 5분 신선
+  gcTime:               15 * 60 * 1000, // 15분 후 메모리 정리
+  retry:                1,
+  retryDelay:           2000,
+  refetchOnWindowFocus: false,
 };
 
-// 전체 뉴스 — 어디서 써도 1개의 캐시 공유
+// 전체 뉴스 — 로컬스토리지 캐시가 있으면 즉시 표시
 export function useAllNewsQuery() {
   return useQuery({
-    queryKey: newsKeys.all,
-    queryFn:  fetchAllNews,
+    queryKey:             newsKeys.all,
+    queryFn:              fetchAllNews,
+    initialData:          () => getInitialNewsData('all'),
+    initialDataUpdatedAt: () => getInitialNewsTimestamp('all'),
     ...NEWS_OPTIONS,
   });
 }
 
-// 카테고리별 뉴스 (뉴스 섹션 필터 탭용)
+// 카테고리별 뉴스
 export function useCategoryNewsQuery(category) {
   return useQuery({
-    queryKey: newsKeys.category(category),
-    queryFn:  () => fetchNewsByCategory(category),
+    queryKey:             newsKeys.category(category),
+    queryFn:              () => fetchNewsByCategory(category),
+    initialData:          () => getInitialNewsData(category),
+    initialDataUpdatedAt: () => getInitialNewsTimestamp(category),
     ...NEWS_OPTIONS,
     enabled: !!category,
   });
 }
 
-// 자동 갱신 포함 (5분 interval — BreakingNewsPanel용)
+// 자동 갱신 포함 (BreakingNewsPanel용)
 export function useNewsAutoRefetch() {
   return useQuery({
-    queryKey:        newsKeys.all,
-    queryFn:         fetchAllNews,
+    queryKey:             newsKeys.all,
+    queryFn:              fetchAllNews,
+    initialData:          () => getInitialNewsData('all'),
+    initialDataUpdatedAt: () => getInitialNewsTimestamp('all'),
     ...NEWS_OPTIONS,
     refetchInterval: 5 * 60 * 1000,
   });
 }
 
-// 수동 새로고침 훅
+// 수동 새로고침
 export function useNewsRefresh() {
   const qc = useQueryClient();
   return () => {


### PR DESCRIPTION
## Summary
- 뉴스 로딩 스피너 제거: initialData 패턴으로 로컬스토리지 캐시 즉시 표시
- 고래 알림 임계값 1억원으로 낮춰 실제 이벤트 표시
- WebSocket 자동 재연결

## Changes
- `news.js`: allorigins 호출 제거, 타임아웃 단축, initialData 헬퍼 export
- `useNewsQuery.js`: initialData + initialDataUpdatedAt 패턴 적용
- `whale.js`: 1억원 임계값, 재연결 로직, _connected 콜백
- `WhalePanel.jsx`: 에러 상태 단순화, 연결 메시지 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)