### PR TITLE
fix: 탭 컬럼 헤더-셀 정렬 수정

### DIFF
--- a/src/components/StockRow.jsx
+++ b/src/components/StockRow.jsx
@@ -39,22 +39,25 @@ export default function StockRow({ item, rank, coinUnit = 'usd', onClick }) {
       {/* 스파크라인 */}
       <Sparkline data={item.sparkline} width={52} height={22} positive={isUp ? true : isDown ? false : undefined} />
 
-      {/* 가격 */}
-      <div className="text-right flex-shrink-0">
-        <div className="text-[15px] font-semibold text-text1 tabular-nums leading-tight">
+      {/* 현재가 */}
+      <div className="flex-shrink-0 w-[88px] text-right">
+        <div className="text-[14px] font-semibold text-text1 tabular-nums leading-tight truncate">
           {fmtPrice(item, coinUnit)}
         </div>
-        <div className={`text-[12px] tabular-nums mt-0.5 font-medium ${isUp ? 'text-up' : isDown ? 'text-down' : 'text-text2'}`}>
+      </div>
+
+      {/* 등락률 */}
+      <div className="flex-shrink-0 w-[60px] text-right">
+        <div className={`text-[13px] tabular-nums font-semibold ${isUp ? 'text-up' : isDown ? 'text-down' : 'text-text2'}`}>
           {isUp ? '+' : ''}{pct?.toFixed(2)}%
         </div>
       </div>
 
       {/* 거래량 */}
-      <div className="flex-shrink-0 w-[68px] text-right">
+      <div className="flex-shrink-0 w-[64px] text-right">
         <div className="text-[11px] text-text3 tabular-nums">
           {fmtLarge(isCoin ? item.volume24h : item.volume) || '—'}
         </div>
-        <div className="text-[10px] text-text3/60">거래량</div>
       </div>
     </div>
   );

--- a/src/components/tabs/CoinTab.jsx
+++ b/src/components/tabs/CoinTab.jsx
@@ -52,8 +52,9 @@ export default function CoinTab({ coins = [], onCardClick }) {
           <span className="text-[11px] text-text3 w-4 flex-shrink-0" />
           <span className="flex-1 text-[11px] text-text3">종목</span>
           <span className="w-[52px] text-[11px] text-text3 text-center">추세</span>
-          <span className="w-[80px] text-[11px] text-text3 text-right">현재가</span>
-          <span className="w-[68px] text-[11px] text-text3 text-right">24h 거래량</span>
+          <span className="w-[88px] text-[11px] text-text3 text-right">현재가</span>
+          <span className="w-[60px] text-[11px] text-text3 text-right">등락률</span>
+          <span className="w-[64px] text-[11px] text-text3 text-right">24h 거래량</span>
         </div>
         {items.map((item, i) => (
           <StockRow key={item.id} item={item} rank={i + 1} coinUnit={coinUnit} onClick={onCardClick} />

--- a/src/components/tabs/EtfTab.jsx
+++ b/src/components/tabs/EtfTab.jsx
@@ -55,8 +55,9 @@ export default function EtfTab({ etfs = [], onCardClick }) {
           <span className="text-[11px] text-text3 w-4 flex-shrink-0" />
           <span className="flex-1 text-[11px] text-text3">종목</span>
           <span className="w-[52px] text-[11px] text-text3 text-center">추세</span>
-          <span className="w-[80px] text-[11px] text-text3 text-right">현재가</span>
-          <span className="w-[68px] text-[11px] text-text3 text-right">AUM</span>
+          <span className="w-[88px] text-[11px] text-text3 text-right">현재가</span>
+          <span className="w-[60px] text-[11px] text-text3 text-right">등락률</span>
+          <span className="w-[64px] text-[11px] text-text3 text-right">AUM</span>
         </div>
         {items.map((item, i) => (
           <StockRow key={item.symbol} item={toRow(item)} rank={i + 1} onClick={onCardClick} />

--- a/src/components/tabs/KoreanTab.jsx
+++ b/src/components/tabs/KoreanTab.jsx
@@ -58,8 +58,9 @@ export default function KoreanTab({ stocks = [], onCardClick }) {
           <span className="text-[11px] text-text3 w-4 flex-shrink-0" />
           <span className="flex-1 text-[11px] text-text3">종목</span>
           <span className="w-[52px] text-[11px] text-text3 text-center">추세</span>
-          <span className="w-[80px] text-[11px] text-text3 text-right">현재가</span>
-          <span className="w-[68px] text-[11px] text-text3 text-right">거래량</span>
+          <span className="w-[88px] text-[11px] text-text3 text-right">현재가</span>
+          <span className="w-[60px] text-[11px] text-text3 text-right">등락률</span>
+          <span className="w-[64px] text-[11px] text-text3 text-right">거래량</span>
         </div>
         {items.map((item, i) => (
           <StockRow key={item.symbol} item={item} rank={i + 1} onClick={onCardClick} />

--- a/src/components/tabs/UsTab.jsx
+++ b/src/components/tabs/UsTab.jsx
@@ -53,8 +53,9 @@ export default function UsTab({ stocks = [], onCardClick }) {
           <span className="text-[11px] text-text3 w-4 flex-shrink-0" />
           <span className="flex-1 text-[11px] text-text3">종목</span>
           <span className="w-[52px] text-[11px] text-text3 text-center">추세</span>
-          <span className="w-[80px] text-[11px] text-text3 text-right">현재가(USD)</span>
-          <span className="w-[68px] text-[11px] text-text3 text-right">거래량</span>
+          <span className="w-[88px] text-[11px] text-text3 text-right">현재가(USD)</span>
+          <span className="w-[60px] text-[11px] text-text3 text-right">등락률</span>
+          <span className="w-[64px] text-[11px] text-text3 text-right">거래량</span>
         </div>
         {items.map((item, i) => (
           <StockRow key={item.symbol} item={item} rank={i + 1} onClick={onCardClick} />


### PR DESCRIPTION
## Summary
- StockRow 가격 컬럼에 명시적 너비(`w-[88px]`) 추가 → 헤더와 정렬 일치
- 등락률(%)을 가격 아래 서브텍스트에서 독립 컬럼(`w-[60px]`)으로 분리
- 거래량 셀 내부 "거래량" 서브 레이블 제거 (헤더와 중복)
- 모든 탭 헤더 너비 통일: 추세 52px / 현재가 88px / 등락률 60px / 거래량·AUM 64px
- ETF 탭 마지막 컬럼 "AUM" 헤더 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)