### PR TITLE
fix: 연관종목/컬럼정렬/언론사명 핵심 버그 3종 수정

### DIFF
--- a/src/components/BreakingNewsPanel.jsx
+++ b/src/components/BreakingNewsPanel.jsx
@@ -46,7 +46,6 @@ function NewsItem({ item }) {
         >
           {cat.label}
         </span>
-        <span className="text-[11px] text-[#B0B8C1] truncate">{item.source}</span>
         <span className="text-[11px] text-[#B0B8C1] flex-shrink-0 ml-auto">{item.timeAgo}</span>
       </div>
       {/* 시그널 태그 — 제목 위에 표시 */}

--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -193,8 +193,9 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
     for (const s of krStocks) { dataMap[s.symbol] = s; if (s.name) dataMap[s.name] = s; }
     for (const s of usStocks) dataMap[s.symbol] = s;
     for (const c of coins)    dataMap[c.symbol?.toUpperCase()] = c;
-    const key = item.name || item.symbol;
-    return findRelatedItems(key, dataMap);
+    // RELATED_ASSETS 키는 대문자 심볼 (BTC, NVDA, 005930 등) 기준
+    const sym = item.symbol?.toUpperCase() || item.id?.toUpperCase() || '';
+    return findRelatedItems(sym, dataMap);
   }, [item?.symbol, item?.name, allData]);
 
   const pct    = item ? getPct(item) : 0;

--- a/src/components/tabs/CoinTab.jsx
+++ b/src/components/tabs/CoinTab.jsx
@@ -48,7 +48,7 @@ export default function CoinTab({ coins = [], onCardClick }) {
           <span className="text-[11px] text-green-500 font-semibold">● CoinGecko 실시간</span>
         </div>
         {/* 컬럼 헤더 */}
-        <div className="flex items-center px-4 py-2 border-b border-[#F2F4F6] bg-[#FAFBFC]">
+        <div className="flex items-center gap-3 px-5 py-2 border-b border-[#F2F4F6] bg-[#FAFBFC]">
           <span className="text-[11px] text-text3 w-4 flex-shrink-0" />
           <span className="flex-1 text-[11px] text-text3">종목</span>
           <span className="w-[52px] text-[11px] text-text3 text-center">추세</span>

--- a/src/components/tabs/EtfTab.jsx
+++ b/src/components/tabs/EtfTab.jsx
@@ -51,7 +51,7 @@ export default function EtfTab({ etfs = [], onCardClick }) {
       <div className="section-card">
         <div className="px-4 py-2.5 border-b border-[#F2F4F6] text-[12px] text-text3">{items.length}개 ETF</div>
         {/* 컬럼 헤더 */}
-        <div className="flex items-center px-4 py-2 border-b border-[#F2F4F6] bg-[#FAFBFC]">
+        <div className="flex items-center gap-3 px-5 py-2 border-b border-[#F2F4F6] bg-[#FAFBFC]">
           <span className="text-[11px] text-text3 w-4 flex-shrink-0" />
           <span className="flex-1 text-[11px] text-text3">종목</span>
           <span className="w-[52px] text-[11px] text-text3 text-center">추세</span>

--- a/src/components/tabs/KoreanTab.jsx
+++ b/src/components/tabs/KoreanTab.jsx
@@ -54,7 +54,7 @@ export default function KoreanTab({ stocks = [], onCardClick }) {
       <div className="section-card">
         <div className="px-4 py-2.5 border-b border-[#F2F4F6] text-[12px] text-text3">{items.length}개 종목</div>
         {/* 컬럼 헤더 */}
-        <div className="flex items-center px-4 py-2 border-b border-[#F2F4F6] bg-[#FAFBFC]">
+        <div className="flex items-center gap-3 px-5 py-2 border-b border-[#F2F4F6] bg-[#FAFBFC]">
           <span className="text-[11px] text-text3 w-4 flex-shrink-0" />
           <span className="flex-1 text-[11px] text-text3">종목</span>
           <span className="w-[52px] text-[11px] text-text3 text-center">추세</span>

--- a/src/components/tabs/UsTab.jsx
+++ b/src/components/tabs/UsTab.jsx
@@ -49,7 +49,7 @@ export default function UsTab({ stocks = [], onCardClick }) {
       <div className="section-card">
         <div className="px-4 py-2.5 border-b border-[#F2F4F6] text-[12px] text-text3">{items.length}개 종목</div>
         {/* 컬럼 헤더 */}
-        <div className="flex items-center px-4 py-2 border-b border-[#F2F4F6] bg-[#FAFBFC]">
+        <div className="flex items-center gap-3 px-5 py-2 border-b border-[#F2F4F6] bg-[#FAFBFC]">
           <span className="text-[11px] text-text3 w-4 flex-shrink-0" />
           <span className="flex-1 text-[11px] text-text3">종목</span>
           <span className="w-[52px] text-[11px] text-text3 text-center">추세</span>


### PR DESCRIPTION
## 수정 내용

### 🐛 연관종목 조회 키 오류 (핵심 버그)
- **원인**: `ChartSidePanel`에서 `findRelatedItems(item.name, ...)` 호출 — `item.name`이 `"비트코인"` 같은 한국어인데 RELATED_ASSETS 키는 `"BTC"` 대문자 심볼이라 항상 빈 배열 반환
- **수정**: `item.symbol?.toUpperCase() || item.id?.toUpperCase()` 로 변경

### 🗞️ 뉴스 언론사명 제거
- `BreakingNewsPanel` 뉴스 아이템에서 `{item.source}` 스팬 제거

### 📐 컬럼 헤더 정렬 불일치
- **원인**: `stock-row` 클래스는 `px-5 gap-3`인데 헤더는 `px-4` + gap 없음 → 모든 열이 좌측으로 밀림
- **수정**: 4개 탭(국내/미장/ETF/코인) 헤더에 `gap-3 px-5` 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)