### PR TITLE
fix: 관련종목/뉴스/등락률정렬/코스피/섹터필터 전면 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -209,6 +209,7 @@ export default function App() {
                 loading={loading && indices.every(i => !i.value)}
               />
               <WatchlistTable
+                key={activeTab}
                 items={tabItems}
                 type={activeTab}
                 krwRate={krwRate}
@@ -234,7 +235,7 @@ export default function App() {
           krwRate={krwRate}
           onClose={() => setSelectedItem(null)}
           onRelatedClick={setSelectedItem}
-          allData={{ krStocks, usStocks, coins }}
+          allData={{ krStocks, usStocks, coins, etfs }}
         />
       )}
     </div>

--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -216,22 +216,23 @@ async function fetchYahooRace(symbol, id) {
 // ─── Stooq 한국 지수 (CORS 허용, 실시간에 가까운 데이터) ──────
 // 검증 결과: ^kospi 동작 확인, ^kosdaq N/D
 async function fetchStooqKospi() {
-  // Stooq CSV 형식: Symbol,Date,Time,Open,High,Low,Close,Volume,
-  const res = await fetch('https://stooq.com/q/l/?s=^kospi&f=sd2t2ohlcvn&h&e=json', {
+  // f=sd2t2ohlcvnp: p 필드로 전일 종가(Prev_Close) 포함
+  const res = await fetch('https://stooq.com/q/l/?s=^kospi&f=sd2t2ohlcvnp&h&e=json', {
     signal: AbortSignal.timeout(5000),
   });
   if (!res.ok) throw new Error(`Stooq KOSPI ${res.status}`);
   const data = await res.json();
   const s = (data.symbols || []).find(x => x.Close && x.Close !== 'N/D');
   if (!s) throw new Error('Stooq KOSPI: N/D');
-  const close = parseFloat(s.Close);
-  const open  = parseFloat(s.Open) || close;
+  const close     = parseFloat(s.Close);
+  // Prev_Close(p 필드) 전일 종가 기준 등락 계산 — Open 대비(당일시가) 아닌 전일종가 대비
+  const prevClose = parseFloat(s.Prev_Close || s.Open) || close;
   return {
     id:        'KOSPI',
     value:     parseFloat(close.toFixed(2)),
-    change:    parseFloat((close - open).toFixed(2)),
-    changePct: parseFloat(((close - open) / open * 100).toFixed(2)),
-    isDelayed: false, // Stooq는 실시간(추정)
+    change:    parseFloat((close - prevClose).toFixed(2)),
+    changePct: parseFloat(((close - prevClose) / prevClose * 100).toFixed(2)),
+    isDelayed: false,
     dataDelay: '실시간(추정)',
   };
 }

--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -183,15 +183,16 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
   const [chartType, setChartType] = useState('candle');
 
   // 종목 키워드 기반 관련 뉴스 — React Query 캐시 활용
-  const relatedNews = useStockNews(item?.symbol || item?.id, item?.name || item?.nameEn);
+  const { news: relatedNews, isLoading: newsLoading } = useStockNews(item?.symbol || item?.id, item?.name || item?.nameEn);
 
   // 연관 종목 — relatedAssets 매핑 기반, allData에서 현재 가격 조회
   const relatedItems = useMemo(() => {
     if (!item) return [];
-    const { krStocks = [], usStocks = [], coins = [] } = allData;
+    const { krStocks = [], usStocks = [], coins = [], etfs = [] } = allData;
     const dataMap = {};
     for (const s of krStocks) { dataMap[s.symbol] = s; if (s.name) dataMap[s.name] = s; }
     for (const s of usStocks) dataMap[s.symbol] = s;
+    for (const e of etfs)     dataMap[e.symbol] = e;
     for (const c of coins)    dataMap[c.symbol?.toUpperCase()] = c;
     // RELATED_ASSETS 키는 대문자 심볼 (BTC, NVDA, 005930 등) 기준
     const sym = item.symbol?.toUpperCase() || item.id?.toUpperCase() || '';
@@ -430,7 +431,11 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
             <div className="text-[11px] font-semibold text-[#B0B8C1] uppercase tracking-wide px-4 mb-2">
               관련 뉴스
             </div>
-            {relatedNews.length === 0 ? (
+            {newsLoading ? (
+              <div className="px-4 py-4 text-center text-[12px] text-[#B0B8C1]">
+                뉴스 로딩 중...
+              </div>
+            ) : relatedNews.length === 0 ? (
               <div className="px-4 py-4 text-center text-[12px] text-[#B0B8C1]">
                 관련 뉴스 없음
               </div>

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -315,6 +315,7 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
   const [sortDir, setSortDir] = useState('desc');
   const [search,  setSearch]  = useState('');
   const [filter,  setFilter]  = useState('all');
+  const [sector,  setSector]  = useState(null);
   const [showWatchlistOnly, setShowWatchlistOnly] = useState(false);
   const { toggle, isWatched, watchlist } = useWatchlist();
 
@@ -326,7 +327,7 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
   const sortFn = (list) => [...list].sort((a, b) => {
     let va, vb;
     if (sortKey === 'changePct') {
-      va = Math.abs(getPct(a)); vb = Math.abs(getPct(b));
+      va = getPct(a); vb = getPct(b);
     } else if (sortKey === 'price') {
       va = a.id ? (a.priceKrw || (a.priceUsd ?? 0) * krwRate) : (a.market === 'us' ? (a.price ?? 0) * krwRate : (a.price ?? 0));
       vb = b.id ? (b.priceKrw || (b.priceUsd ?? 0) * krwRate) : (b.market === 'us' ? (b.price ?? 0) * krwRate : (b.price ?? 0));
@@ -351,6 +352,7 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
         (i.symbol || '').toLowerCase().includes(q)
       );
     }
+    if (sector) list = list.filter(i => i.sector === sector);
     if (filter === 'up')        list = list.filter(i => getPct(i) > 0);
     if (filter === 'down')      list = list.filter(i => getPct(i) < 0);
     if (filter === 'hot')       list = list.filter(i => getPct(i) >= 3);
@@ -358,7 +360,14 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
     // ★ 관심종목만 보기 토글
     if (showWatchlistOnly)      list = list.filter(i => isWatched(i.id || i.symbol));
     return list;
-  }, [items, search, filter, showWatchlistOnly, watchlist, isWatched]);
+  }, [items, search, filter, sector, showWatchlistOnly, watchlist, isWatched]);
+
+  // items에서 고유 섹터 목록 동적 추출 (kr/us 탭에서만 의미있음)
+  const availableSectors = useMemo(() => {
+    if (type === 'coin' || type === 'all') return [];
+    const s = new Set(items.map(i => i.sector).filter(Boolean));
+    return [...s].sort();
+  }, [items, type]);
 
   const hotCount = items.filter(i => getPct(i) >= 3).length;
   const isAll = type === 'all';
@@ -459,6 +468,31 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
             </button>
           ))}
         </div>
+
+        {/* 섹터 필터 칩 — kr/us 탭에만 표시 */}
+        {availableSectors.length > 0 && (
+          <div className="flex gap-1 overflow-x-auto no-scrollbar flex-wrap max-w-full">
+            <button
+              onClick={() => setSector(null)}
+              className={`px-2.5 py-1.5 text-[11px] rounded-lg font-semibold transition-colors flex-shrink-0 ${
+                !sector ? 'bg-[#3182F6] text-white' : 'bg-[#F2F4F6] text-[#6B7684] hover:bg-[#E5E8EB]'
+              }`}
+            >
+              전체
+            </button>
+            {availableSectors.map(s => (
+              <button
+                key={s}
+                onClick={() => setSector(prev => prev === s ? null : s)}
+                className={`px-2.5 py-1.5 text-[11px] rounded-lg font-semibold transition-colors flex-shrink-0 ${
+                  sector === s ? 'bg-[#3182F6] text-white' : 'bg-[#F2F4F6] text-[#6B7684] hover:bg-[#E5E8EB]'
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
 
         {/* ★ 관심종목만 보기 토글 버튼 */}
         <button

--- a/src/data/mock.js
+++ b/src/data/mock.js
@@ -341,6 +341,13 @@ export const US_STOCKS_INITIAL = [
   { symbol:'SNAP',  name:'스냅',          nameEn:'Snap',             market:'us', sector:'소셜미디어',  price:8.45,   change:0.25,  changePct:3.05,  volume:35000000,  marketCap:0.014e12, high52w:17.53,  low52w:8.20   },
   { symbol:'MTCH',  name:'매치그룹',      nameEn:'Match Group',      market:'us', sector:'인터넷',     price:28.45,  change:0.52,  changePct:1.86,  volume:5500000,   marketCap:0.008e12, high52w:39.23,  low52w:26.11  },
   { symbol:'IAC',   name:'IAC',           nameEn:'IAC',              market:'us', sector:'인터넷',     price:38.45,  change:0.85,  changePct:2.26,  volume:3200000,   marketCap:0.004e12, high52w:58.98,  low52w:34.00  },
+  // ─── BTC 채굴/보유 관련주 ─────────────────────────────────────
+  { symbol:'RIOT',  name:'라이엇 플랫폼스',  nameEn:'Riot Platforms',  market:'us', sector:'BTC채굴',   price:10.45, change:0.75,  changePct:7.74,  volume:35000000, marketCap:0.025e12, high52w:22.50, low52w:7.50  },
+  { symbol:'MARA',  name:'마라 홀딩스',      nameEn:'MARA Holdings',   market:'us', sector:'BTC채굴',   price:14.85, change:1.12,  changePct:8.15,  volume:28000000, marketCap:0.030e12, high52w:31.66, low52w:9.50  },
+  { symbol:'CLSK',  name:'클린스파크',       nameEn:'CleanSpark',      market:'us', sector:'BTC채굴',   price:12.85, change:0.95,  changePct:7.98,  volume:18000000, marketCap:0.018e12, high52w:27.52, low52w:7.95  },
+  { symbol:'HUT',   name:'허트8',           nameEn:'Hut 8',           market:'us', sector:'BTC채굴',   price:19.45, change:1.55,  changePct:8.66,  volume:8500000,  marketCap:0.015e12, high52w:35.55, low52w:9.40  },
+  { symbol:'CORZ',  name:'코어사이언티픽',  nameEn:'Core Scientific', market:'us', sector:'BTC채굴',   price:12.45, change:0.98,  changePct:8.55,  volume:25000000, marketCap:0.020e12, high52w:20.10, low52w:4.82  },
+  { symbol:'BITF',  name:'비트팜스',        nameEn:'Bitfarms',        market:'us', sector:'BTC채굴',   price:2.85,  change:0.22,  changePct:8.36,  volume:15000000, marketCap:0.008e12, high52w:5.63,  low52w:1.40  },
 ].map(s => ({ ...s, sparkline: genSparkline(s.price, 20, 0.015) }));
 
 // ─── 코인 초기값 (Upbit 2026-03-13 실제가, CoinGecko로 즉시 갱신됨) ─
@@ -453,6 +460,13 @@ export const ETF_DATA = [
   { symbol:'SOXL',   name:'Direxion Semi Bull 3X',      market:'us', sector:'Leverage', category:'레버리지', price:21.45, change:1.12,  changePct:5.51,  volume:62000000, aum:9e9    },
   { symbol:'SOXS',   name:'Direxion Semi Bear 3X',      market:'us', sector:'Inverse',  category:'인버스',   price:8.32,  change:-0.55, changePct:-6.20, volume:38000000, aum:1.5e9  },
   { symbol:'TLT',    name:'iShares 20Y+ Treasury',      market:'us', sector:'Bond',     category:'채권',     price:86.45, change:0.45,  changePct:0.52,  volume:22000000, aum:40e9   },
+  // ─── BTC/ETH 현물 ETF ────────────────────────────────────────
+  { symbol:'IBIT',  name:'iShares Bitcoin Trust',      market:'us', sector:'BTC ETF',  category:'코인ETF', price:52.45,  change:2.85,  changePct:5.75,  volume:42000000, aum:38e9  },
+  { symbol:'FBTC',  name:'Fidelity Bitcoin',           market:'us', sector:'BTC ETF',  category:'코인ETF', price:75.32,  change:4.12,  changePct:5.79,  volume:18000000, aum:18e9  },
+  { symbol:'GBTC',  name:'Grayscale Bitcoin Trust',    market:'us', sector:'BTC ETF',  category:'코인ETF', price:61.85,  change:3.42,  changePct:5.86,  volume:12000000, aum:21e9  },
+  { symbol:'ETHA',  name:'iShares Ethereum Trust',     market:'us', sector:'ETH ETF',  category:'코인ETF', price:24.85,  change:1.45,  changePct:6.19,  volume:8500000,  aum:3.2e9 },
+  { symbol:'ETHE',  name:'Grayscale Ethereum Trust',   market:'us', sector:'ETH ETF',  category:'코인ETF', price:18.45,  change:1.12,  changePct:6.47,  volume:4500000,  aum:5.8e9 },
+  { symbol:'FETH',  name:'Fidelity Ethereum',          market:'us', sector:'ETH ETF',  category:'코인ETF', price:28.45,  change:1.75,  changePct:6.56,  volume:6200000,  aum:2.1e9 },
   { symbol:'373220', name:'KODEX 2차전지산업',           market:'kr', sector:'배터리',   category:'섹터',     price:12850, change:185,   changePct:1.46,  volume:8500000,  aum:2.1e12 },
   { symbol:'091230', name:'TIGER 반도체',                market:'kr', sector:'반도체',   category:'섹터',     price:27650, change:455,   changePct:1.67,  volume:2100000,  aum:1.8e12 },
   { symbol:'122630', name:'KODEX 레버리지',              market:'kr', sector:'레버리지', category:'레버리지', price:15420, change:-285,  changePct:-1.82, volume:28000000, aum:4.2e12 },

--- a/src/hooks/useNewsQuery.js
+++ b/src/hooks/useNewsQuery.js
@@ -66,16 +66,23 @@ export function useNewsRefresh() {
 
 // 종목 키워드 기반 뉴스 필터 훅 — ChartSidePanel에서 사용
 export function useStockNews(symbol, name) {
-  const { data: allNews = [] } = useAllNewsQuery();
+  const { data: allNews = [], isLoading } = useAllNewsQuery();
 
-  if (!symbol) return [];
+  if (!symbol) return { news: [], isLoading: false };
 
-  const keywords = [symbol, name].filter(Boolean).map(k => k.toLowerCase());
+  // 영문명이 너무 길면 첫 단어만 사용 (예: "Apple" not "Apple Inc.")
+  const shortName = name ? name.split(/[\s\/]/)[0] : null;
+  const keywords = [symbol, name, shortName]
+    .filter(Boolean)
+    .map(k => k.toLowerCase())
+    .filter((k, i, arr) => arr.indexOf(k) === i); // 중복 제거
 
-  return allNews
+  const news = allNews
     .filter(item => {
       const text = (item.title + ' ' + (item.summary || item.description || '')).toLowerCase();
-      return keywords.some(kw => text.includes(kw));
+      return keywords.some(kw => kw.length >= 2 && text.includes(kw));
     })
-    .slice(0, 5);
+    .slice(0, 6);
+
+  return { news, isLoading };
 }


### PR DESCRIPTION
## 수정 내역
- 탭 전환 시 WatchlistTable 필터 초기화 (key={activeTab})
- ChartSidePanel allData에 etfs 추가 → BTC ETF 관련종목 표시
- IBIT, FBTC, GBTC, ETHA, ETHE, RIOT, MARA 등 12개 종목 추가
- 코스피 Stooq: 당일시가 대비 → 전일종가 대비로 계산 수정
- 등락률 정렬 Math.abs 제거 → 상승 종목이 상위에 정렬
- 섹터 칩 필터 WatchlistTable에 추가
- useStockNews loading state 반환 → 뉴스 로딩 중 스켈레톤 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)