### PR TITLE
redesign: 홈 화면 전면 재설계 + 디자인 개선

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -175,7 +175,7 @@ export default function App() {
     <div className="min-h-screen bg-[#F8F9FA]">
       {/* 급상승 배너 (sticky, z-30 — 차트 패널 z-150보다 낮게) */}
       <div className="sticky top-0 z-30">
-        <SurgeBanner stocks={allStocks} coins={coins} />
+        <SurgeBanner stocks={allStocks} coins={coins} onClick={setSelectedItem} />
       </div>
 
       {/* 헤더 (sticky, z-20) */}
@@ -186,6 +186,9 @@ export default function App() {
         loading={loading}
         activeTab={activeTab}
         onTabChange={setActiveTab}
+        krStocks={krStocks}
+        usStocks={usStocks}
+        coins={coins}
       />
 
       {/* ── 반응형 그리드 레이아웃: 모바일 1열 / 데스크탑 2열 ─── */}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,17 +1,34 @@
 // 데스크탑 헤더 — 탭 + 장 상태 + 환율 + 새로고침
+// 탭: active 상태 개선 (underline + filled bg), 뱃지 🔥, 이모지 레이블
 import { getKoreanMarketStatus, getUsMarketStatus } from '../utils/marketHours';
 import { fmt } from '../utils/format';
 
-// B안: '전체' 탭 제거, 홈 탭이 전체 통합 역할
 const TABS = [
-  { id: 'home', label: '🔥 지금 핫한 것' },
+  { id: 'home', label: '🏠 홈' },
   { id: 'kr',   label: '🇰🇷 국내' },
-  { id: 'us',   label: '🇺🇸 해외' },
+  { id: 'us',   label: '🇺🇸 미장' },
   { id: 'coin', label: '🪙 코인' },
   { id: 'etf',  label: '📊 ETF' },
 ];
 
-export default function Header({ krwRate, lastUpdated, onRefresh, loading, activeTab, onTabChange }) {
+// 탭별 급등 강조 여부 판단 함수 (props로 받은 종목 데이터 활용)
+function getTabHasSurge(id, { krStocks, usStocks, coins }) {
+  const check = (items, pctKey) => items.some(s => (s[pctKey] ?? 0) >= 3);
+  if (id === 'kr')   return check(krStocks, 'changePct');
+  if (id === 'us')   return check(usStocks, 'changePct');
+  if (id === 'coin') return check(coins, 'change24h');
+  if (id === 'home') return (
+    check(krStocks, 'changePct') ||
+    check(usStocks, 'changePct') ||
+    check(coins, 'change24h')
+  );
+  return false;
+}
+
+export default function Header({
+  krwRate, lastUpdated, onRefresh, loading, activeTab, onTabChange,
+  krStocks = [], usStocks = [], coins = [],
+}) {
   const kr = getKoreanMarketStatus();
   const us = getUsMarketStatus();
   const timeStr = lastUpdated
@@ -23,25 +40,37 @@ export default function Header({ krwRate, lastUpdated, onRefresh, loading, activ
       <div className="max-w-[1440px] mx-auto px-6 h-14 flex items-center justify-between">
 
         {/* 좌: 로고 + 탭 */}
-        <div className="flex items-center gap-6">
+        <div className="flex items-center gap-5">
           <span className="text-[20px] font-bold text-[#191F28] tracking-tight flex-shrink-0">
             마켓레이더
           </span>
           {/* 탭 — 모바일에서 가로 스크롤 지원 */}
-          <nav className="flex items-center gap-1 overflow-x-auto no-scrollbar">
-            {TABS.map(tab => (
-              <button
-                key={tab.id}
-                onClick={() => onTabChange(tab.id)}
-                className={`flex-shrink-0 px-4 py-2 rounded-lg text-[14px] font-medium transition-colors ${
-                  activeTab === tab.id
-                    ? 'bg-[#191F28] text-white'
-                    : 'text-[#6B7684] hover:bg-[#F2F4F6] hover:text-[#191F28]'
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
+          <nav className="flex items-center gap-0.5 overflow-x-auto no-scrollbar">
+            {TABS.map(tab => {
+              const isActive = activeTab === tab.id;
+              const hasSurge = getTabHasSurge(tab.id, { krStocks, usStocks, coins });
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => onTabChange(tab.id)}
+                  className={`relative flex-shrink-0 flex items-center gap-1 px-3 py-2 text-[13px] font-medium transition-all rounded-lg ${
+                    isActive
+                      ? 'bg-[#191F28] text-white font-bold'
+                      : 'text-[#6B7684] hover:bg-[#F2F4F6] hover:text-[#191F28]'
+                  }`}
+                >
+                  {tab.label}
+                  {/* 급등 🔥 뱃지 */}
+                  {hasSurge && !isActive && (
+                    <span className="text-[10px] leading-none">🔥</span>
+                  )}
+                  {/* active 탭 하단 underline 강조 */}
+                  {isActive && (
+                    <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-4 h-0.5 rounded-full bg-white opacity-60" />
+                  )}
+                </button>
+              );
+            })}
           </nav>
         </div>
 

--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -1,11 +1,12 @@
-// 홈 대시보드 — 레이아웃 순서
-// ① 인사이트 카드 (뉴스 시그널 기반 — 최상단)
-// ② 시장 맥락 바 (지수)
-// ③ 급등/급락 TOP10 + 탭 필터 [전체|KR|US|COIN] (인라인 관련종목 chip)
-// ④ 코인 요약 카드 (공포탐욕+도미넌스+김프) — 접기/펼치기
+// 홈 대시보드 — 전면 재설계
+// ① 급등 스포트라이트 (전체/KR/US/코인 탭 필터, 카드 형태)
+// ② 시장 지수 요약 바 (compact 스트립)
+// ③ 3열 HOT 리스트 (국내/미장/코인 각 TOP5)
+// ④ 인사이트 카드 (뉴스 시그널 기반, compact 가로 스크롤)
 
 import { useState, useMemo, memo, useCallback } from 'react';
 import MarketSummaryCards from './MarketSummaryCards';
+import Sparkline from './Sparkline';
 import { useAllNewsQuery } from '../hooks/useNewsQuery';
 import { findRelatedItems, MARKET_FLAG, RELATION_TYPES } from '../data/relatedAssets';
 import { extractNewsSignals } from '../utils/newsSignal';
@@ -81,6 +82,12 @@ function fmt(n, d = 0) {
   return Number(n).toLocaleString('ko-KR', { minimumFractionDigits: d, maximumFractionDigits: d });
 }
 
+// 종목 등락률 추출 (KR/US/COIN 통합)
+function getPct(item) {
+  if (item._market === 'COIN') return item.change24h ?? 0;
+  return item.changePct ?? 0;
+}
+
 // ─── 시장 배지 팔레트 ─────────────────────────────────────────
 const MARKET_BADGE = {
   KR:   { bg: '#FFF0F0', color: '#F04452' },
@@ -97,41 +104,188 @@ const TYPE_BADGE = {
   index:  { bg: '#F2F4F6', color: '#8B95A1', label: '지수' },
 };
 
-// ─── BLOCK 1: 지수 미니 칩 ───────────────────────────────────
-const IndexMiniChip = memo(function IndexMiniChip({ idx }) {
-  const isUp   = (idx.changePct ?? 0) > 0;
-  const isDown = (idx.changePct ?? 0) < 0;
-  const color  = isUp ? '#F04452' : isDown ? '#1764ED' : '#8B95A1';
-  const flag   = { KOSPI: '🇰🇷', KOSDAQ: '🇰🇷', SPX: '🇺🇸', NDX: '🇺🇸', DJI: '🇺🇸', DXY: '🌐' }[idx.id] || '';
+// ─── 로고 아바타 (로고 실패 시 컬러 이니셜) ──────────────────
+const PALETTE = ['#3182F6','#F04452','#FF9500','#2AC769','#8B5CF6','#EC4899','#14B8A6','#F59E0B'];
+function getAvatarBg(symbol) {
+  return PALETTE[(symbol || '').split('').reduce((h, c) => c.charCodeAt(0) + ((h << 5) - h), 0) % PALETTE.length] || '#8B95A1';
+}
+
+// ─── SECTION 1: 급등 스포트라이트 카드 ───────────────────────
+const SurgeCard = memo(function SurgeCard({ item, krwRate, onClick }) {
+  const pct   = getPct(item);
+  const isUp  = pct > 0;
+  const isDown = pct < 0;
+  const color = isUp ? '#F04452' : isDown ? '#1764ED' : '#8B95A1';
+  const badge = MARKET_BADGE[item._market] || { bg: '#F2F4F6', color: '#8B95A1' };
+
+  const logoUrls = item.image ? [item.image]
+    : item._market === 'US'   ? [`https://assets.parqet.com/logos/symbol/${item.symbol}?format=png`]
+    : item._market === 'KR'   ? [`https://file.alphasquare.co.kr/media/images/stock_logo/kr/${item.symbol}.png`]
+    : [];
+  const [logoIdx, setLogoIdx] = useState(0);
+  const bg = getAvatarBg(item.symbol);
+
+  const price = item._market === 'COIN'
+    ? `₩${fmt(Math.round(item.priceKrw || (item.priceUsd ?? 0) * krwRate))}`
+    : item._market === 'KR'
+    ? `₩${fmt(item.price)}`
+    : `₩${fmt(Math.round((item.price ?? 0) * krwRate))}`;
+
+  const sparkData = item.sparkline ?? [];
+  const isHot = Math.abs(pct) >= 3;
 
   return (
-    <div className="flex-shrink-0 bg-white rounded-xl px-3 py-2.5 flex items-center gap-2.5 border border-[#F2F4F6] shadow-sm">
-      <span className="text-[13px]">{flag}</span>
-      <div>
-        <div className="flex items-center gap-1 mb-0.5">
-          <div className="text-[10px] text-[#8B95A1] font-semibold leading-none">{idx.name}</div>
-          {idx.isDelayed && (
-            <span className="text-[9px] text-[#B0B8C1] bg-[#F2F4F6] px-1 rounded">지연</span>
+    <div
+      onClick={() => onClick?.(item)}
+      className="flex-shrink-0 w-[152px] bg-white rounded-2xl border cursor-pointer active:scale-[0.98] transition-all hover:shadow-md hover:border-[#D1D6DB]"
+      style={{
+        borderColor: isHot ? (isUp ? '#FFD6D9' : '#C8DCFF') : '#E5E8EB',
+        background: isHot ? (isUp ? '#FFFAFA' : '#F4F8FF') : '#fff',
+      }}
+    >
+      <div className="p-3.5">
+        {/* 로고 + 마켓 배지 */}
+        <div className="flex items-center justify-between mb-2.5">
+          {logoIdx < logoUrls.length ? (
+            <img
+              src={logoUrls[logoIdx]}
+              alt={item.symbol}
+              onError={() => setLogoIdx(i => i + 1)}
+              className="w-8 h-8 rounded-full object-contain bg-white border border-[#F2F4F6] p-0.5"
+            />
+          ) : (
+            <div
+              className="w-8 h-8 rounded-full flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0"
+              style={{ background: bg }}
+            >
+              {(item.symbol || '?').slice(0, 2).toUpperCase()}
+            </div>
           )}
+          <span
+            className="text-[9px] font-bold px-1.5 py-0.5 rounded-full"
+            style={{ background: badge.bg, color: badge.color }}
+          >
+            {item._market}
+          </span>
         </div>
-        <div className="flex items-baseline gap-1.5">
-          <span className="text-[14px] font-bold text-[#191F28] tabular-nums font-mono">
-            {fmt(idx.value, 2)}
-          </span>
-          <span className="text-[11px] font-bold tabular-nums font-mono" style={{ color }}>
-            {isUp ? '▲' : isDown ? '▼' : '—'}{Math.abs(idx.changePct ?? 0).toFixed(2)}%
-          </span>
+
+        {/* 종목명 + 심볼 */}
+        <div className="mb-2">
+          <div className="text-[13px] font-bold text-[#191F28] truncate leading-tight">{item.name}</div>
+          <div className="text-[10px] text-[#8B95A1] font-mono font-semibold mt-0.5">{item.symbol}</div>
+        </div>
+
+        {/* 가격 */}
+        <div className="text-[13px] font-bold text-[#191F28] tabular-nums font-mono truncate mb-1.5">
+          {price}
+        </div>
+
+        {/* 등락률 배지 */}
+        <div
+          className="inline-flex items-center gap-0.5 px-2 py-0.5 rounded-full text-[11px] font-bold tabular-nums font-mono mb-2"
+          style={{
+            background: isUp ? '#FFF0F0' : isDown ? '#EDF4FF' : '#F2F4F6',
+            color,
+          }}
+        >
+          {isUp ? '▲' : isDown ? '▼' : '—'} {Math.abs(pct).toFixed(2)}%
+        </div>
+
+        {/* 스파크라인 */}
+        <div className="mt-1">
+          <Sparkline data={sparkData} width={120} height={28} positive={isUp ? true : isDown ? false : undefined} />
         </div>
       </div>
     </div>
   );
 });
 
+// ─── SECTION 2: 시장 지수 compact 스트립 아이템 ──────────────
+const IndexStripItem = memo(function IndexStripItem({ idx }) {
+  const isUp   = (idx.changePct ?? 0) > 0;
+  const isDown = (idx.changePct ?? 0) < 0;
+  const color  = isUp ? '#F04452' : isDown ? '#1764ED' : '#8B95A1';
+  const flag   = { KOSPI: '🇰🇷', KOSDAQ: '🇰🇷', SPX: '🇺🇸', NDX: '🇺🇸', DJI: '🇺🇸', DXY: '🌐' }[idx.id] || '';
+
+  return (
+    <div className="flex-shrink-0 flex items-center gap-2 px-3 py-2 rounded-xl bg-white border border-[#F2F4F6] hover:border-[#D1D6DB] hover:bg-[#F7F8FA] cursor-default transition-colors">
+      <span className="text-[12px]">{flag}</span>
+      <span className="text-[11px] text-[#8B95A1] font-medium">{idx.name}</span>
+      <span className="text-[12px] font-bold tabular-nums font-mono" style={{ color }}>
+        {isUp ? '▲' : isDown ? '▼' : '—'}{Math.abs(idx.changePct ?? 0).toFixed(2)}%
+      </span>
+    </div>
+  );
+});
+
+// ─── SECTION 3: HOT 리스트 행 (3열 공통) ─────────────────────
+const HotRow = memo(function HotRow({ item, rank, krwRate, onClick }) {
+  const pct    = getPct(item);
+  const isUp   = pct > 0;
+  const isDown = pct < 0;
+  const color  = isUp ? '#F04452' : isDown ? '#1764ED' : '#8B95A1';
+
+  const logoUrls = item.image ? [item.image]
+    : item._market === 'US'   ? [`https://assets.parqet.com/logos/symbol/${item.symbol}?format=png`]
+    : item._market === 'KR'   ? [`https://file.alphasquare.co.kr/media/images/stock_logo/kr/${item.symbol}.png`]
+    : [];
+  const [logoIdx, setLogoIdx] = useState(0);
+  const bg = getAvatarBg(item.symbol);
+
+  const price = item._market === 'COIN'
+    ? `₩${fmt(Math.round(item.priceKrw || (item.priceUsd ?? 0) * krwRate))}`
+    : item._market === 'KR'
+    ? `₩${fmt(item.price)}`
+    : `₩${fmt(Math.round((item.price ?? 0) * krwRate))}`;
+
+  return (
+    <div
+      onClick={() => onClick?.(item)}
+      className="flex items-center gap-2.5 px-4 py-2.5 cursor-pointer hover:bg-[#F7F8FA] active:scale-[0.99] transition-all rounded-xl"
+    >
+      {/* 순위 */}
+      <span className="w-4 text-[11px] text-[#C9CDD2] tabular-nums font-mono text-center flex-shrink-0">{rank}</span>
+
+      {/* 로고 */}
+      {logoIdx < logoUrls.length ? (
+        <img
+          src={logoUrls[logoIdx]}
+          alt={item.symbol}
+          onError={() => setLogoIdx(i => i + 1)}
+          className="w-6 h-6 rounded-full object-contain bg-white border border-[#F2F4F6] p-0.5 flex-shrink-0"
+        />
+      ) : (
+        <div
+          className="w-6 h-6 rounded-full flex items-center justify-center text-white text-[9px] font-bold flex-shrink-0"
+          style={{ background: bg }}
+        >
+          {(item.symbol || '?').slice(0, 2).toUpperCase()}
+        </div>
+      )}
+
+      {/* 종목명 */}
+      <div className="flex-1 min-w-0">
+        <div className="text-[12px] font-semibold text-[#191F28] truncate">{item.name}</div>
+        <div className="text-[10px] text-[#8B95A1] font-mono truncate">{item.symbol}</div>
+      </div>
+
+      {/* 등락률 + 가격 */}
+      <div className="text-right flex-shrink-0">
+        <div
+          className="text-[12px] font-bold tabular-nums font-mono"
+          style={{ color }}
+        >
+          {isUp ? '▲' : isDown ? '▼' : '—'}{Math.abs(pct).toFixed(2)}%
+        </div>
+        <div className="text-[10px] text-[#8B95A1] tabular-nums font-mono">{price}</div>
+      </div>
+    </div>
+  );
+});
+
 // ─── 관련종목 인라인 chip ─────────────────────────────────────
-// 항상 표시 (호버 불필요), 최대 3개 + "+N" 버튼
 const RelatedChips = memo(function RelatedChips({ relatedItems, onChipClick }) {
   const [showAll, setShowAll] = useState(false);
-
   if (!relatedItems.length) return null;
 
   const MAX_VISIBLE = 3;
@@ -142,10 +296,10 @@ const RelatedChips = memo(function RelatedChips({ relatedItems, onChipClick }) {
     <div className="flex flex-wrap items-center gap-1 pl-[52px] pb-2 pt-0.5">
       <span className="text-[9px] text-[#C9CDD2] font-semibold tracking-wide flex-shrink-0">연관</span>
       {visible.map(({ ticker, type, market, item: rel }) => {
-        const relPct    = rel ? (rel.change24h ?? rel.changePct ?? 0) : null;
-        const relColor  = relPct == null ? '#B0B8C1' : relPct > 0 ? '#F04452' : relPct < 0 ? '#1764ED' : '#8B95A1';
-        const flag      = MARKET_FLAG[market] || '';
-        const arrow     = relPct == null ? '' : relPct > 0 ? '↑' : relPct < 0 ? '↓' : '';
+        const relPct   = rel ? (rel.change24h ?? rel.changePct ?? 0) : null;
+        const relColor = relPct == null ? '#B0B8C1' : relPct > 0 ? '#F04452' : relPct < 0 ? '#1764ED' : '#8B95A1';
+        const flag     = MARKET_FLAG[market] || '';
+        const arrow    = relPct == null ? '' : relPct > 0 ? '↑' : relPct < 0 ? '↓' : '';
 
         return (
           <button
@@ -165,7 +319,6 @@ const RelatedChips = memo(function RelatedChips({ relatedItems, onChipClick }) {
           </button>
         );
       })}
-
       {!showAll && hiddenCount > 0 && (
         <button
           onClick={e => { e.stopPropagation(); setShowAll(true); }}
@@ -178,103 +331,9 @@ const RelatedChips = memo(function RelatedChips({ relatedItems, onChipClick }) {
   );
 });
 
-// ─── BLOCK 2: 통합 무버 행 (인라인 chip 포함) ────────────────
-const MoverRow = memo(function MoverRow({ item, rank, krwRate, onClick, dataMap = {} }) {
-  const pct    = item._market === 'COIN' ? (item.change24h ?? 0) : (item.changePct ?? 0);
-  const isUp   = pct > 0;
-  const isDown = pct < 0;
-  const color  = isUp ? '#F04452' : isDown ? '#1764ED' : '#8B95A1';
-
-  const logoUrls = item.image ? [item.image]
-    : item._market === 'US'   ? [`https://assets.parqet.com/logos/symbol/${item.symbol}?format=png`]
-    : item._market === 'KR'   ? [`https://file.alphasquare.co.kr/media/images/stock_logo/kr/${item.symbol}.png`]
-    : [];
-  const [logoIdx, setLogoIdx] = useState(0);
-
-  const PALETTE = ['#3182F6','#F04452','#FF9500','#2AC769','#8B5CF6','#EC4899','#14B8A6','#F59E0B'];
-  const bg = PALETTE[(item.symbol || '').split('').reduce((h, c) => c.charCodeAt(0) + ((h << 5) - h), 0) % PALETTE.length] || '#8B95A1';
-
-  const price = item._market === 'COIN'
-    ? `₩${fmt(Math.round(item.priceKrw || (item.priceUsd ?? 0) * krwRate))}`
-    : item._market === 'KR'
-    ? `₩${fmt(item.price)}`
-    : `₩${fmt(Math.round((item.price ?? 0) * krwRate))}`;
-
-  const badge = MARKET_BADGE[item._market] || { bg: '#F2F4F6', color: '#8B95A1' };
-
-  // 연관 종목 — relatedAssets 새 구조에서 조회 (useMemo로 re-render 최소화)
-  const relatedKey = item.name || item.symbol;
-  const relatedItems = useMemo(
-    () => findRelatedItems(relatedKey, dataMap),
-    [relatedKey, dataMap]
-  );
-
-  const handleChipClick = useCallback((rel) => onClick?.(rel), [onClick]);
-
-  return (
-    <div className="rounded-xl transition-colors hover:bg-[#FAFBFC]">
-      {/* 메인 행 */}
-      <div
-        onClick={() => onClick?.(item)}
-        className="flex items-center gap-3 px-3 py-2.5 cursor-pointer"
-      >
-        {/* 순위 */}
-        <span className="text-[12px] text-[#C9CDD2] w-4 text-center tabular-nums flex-shrink-0">{rank}</span>
-
-        {/* 로고 */}
-        {logoIdx < logoUrls.length ? (
-          <img
-            src={logoUrls[logoIdx]}
-            alt={item.symbol}
-            onError={() => setLogoIdx(i => i + 1)}
-            className="w-7 h-7 rounded-full object-contain bg-white border border-[#F2F4F6] flex-shrink-0 p-0.5"
-          />
-        ) : (
-          <div
-            className="w-7 h-7 rounded-full flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0"
-            style={{ background: bg }}
-          >
-            {(item.symbol || '?').slice(0, 2).toUpperCase()}
-          </div>
-        )}
-
-        {/* 종목명 + 심볼 */}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5 min-w-0">
-            <span className="text-[13px] font-semibold text-[#191F28] truncate">{item.name}</span>
-            <span
-              className="flex-shrink-0 text-[9px] font-bold px-1 py-0.5 rounded"
-              style={{ background: badge.bg, color: badge.color }}
-            >
-              {item._market}
-            </span>
-          </div>
-          <div className="text-[10px] font-bold text-[#8B95A1] font-mono">{item.symbol}</div>
-        </div>
-
-        {/* 등락률 + 가격 */}
-        <div className="text-right flex-shrink-0">
-          <div className="text-[13px] font-bold tabular-nums font-mono" style={{ color }}>
-            {isUp ? '▲' : isDown ? '▼' : '—'}{Math.abs(pct).toFixed(2)}%
-          </div>
-          <div className="text-[11px] text-[#8B95A1] tabular-nums font-mono">{price}</div>
-        </div>
-      </div>
-
-      {/* 인라인 관련종목 chip — 항상 표시 (호버 불필요) */}
-      {relatedItems.length > 0 && (
-        <RelatedChips
-          relatedItems={relatedItems}
-          onChipClick={handleChipClick}
-        />
-      )}
-    </div>
-  );
-});
-
-// ─── BLOCK 3: 인사이트 카드 (뉴스 시그널 기반) ──────────────
+// ─── SECTION 4: 인사이트 카드 ────────────────────────────────
 const InsightCard = memo(function InsightCard({ mover, news, onMoverClick }) {
-  const pct    = mover._market === 'COIN' ? (mover.change24h ?? 0) : (mover.changePct ?? 0);
+  const pct    = getPct(mover);
   const isUp   = pct > 0;
   const isDown = pct < 0;
   const color  = isUp ? '#F04452' : isDown ? '#1764ED' : '#8B95A1';
@@ -288,10 +347,9 @@ const InsightCard = memo(function InsightCard({ mover, news, onMoverClick }) {
       href={news.link}
       target="_blank"
       rel="noopener noreferrer"
-      className="block rounded-xl border p-3 hover:opacity-90 transition-opacity"
+      className="flex-shrink-0 w-[260px] block rounded-xl border p-3 hover:opacity-90 transition-opacity"
       style={{ background: bgColor, borderColor }}
     >
-      {/* 상단: 종목 + 등락률 + 시장 배지 + 시그널 태그 + 시간 */}
       <div className="flex items-center gap-1.5 mb-2">
         <button
           onClick={e => { e.preventDefault(); onMoverClick?.(mover); }}
@@ -319,7 +377,6 @@ const InsightCard = memo(function InsightCard({ mover, news, onMoverClick }) {
         ))}
         <span className="text-[10px] text-[#B0B8C1] flex-shrink-0 ml-auto">{news.timeAgo}</span>
       </div>
-      {/* 뉴스 헤드라인 */}
       <div className="text-[12px] text-[#4E5968] leading-snug line-clamp-2">
         {news.title}
       </div>
@@ -327,74 +384,6 @@ const InsightCard = memo(function InsightCard({ mover, news, onMoverClick }) {
   );
 });
 
-// ─── 스켈레톤 플레이스홀더 ───────────────────────────────────
-function SkeletonRow({ count = 5 }) {
-  return Array.from({ length: count }).map((_, i) => (
-    <div key={i} className="flex items-center gap-3 px-3 py-2.5">
-      <div className="w-4 h-3 bg-[#F2F4F6] rounded animate-pulse flex-shrink-0" />
-      <div className="w-7 h-7 rounded-full bg-[#F2F4F6] animate-pulse flex-shrink-0" />
-      <div className="flex-1 space-y-1">
-        <div className="h-3 bg-[#F2F4F6] rounded w-24 animate-pulse" />
-        <div className="h-2.5 bg-[#F2F4F6] rounded w-12 animate-pulse" />
-      </div>
-      <div className="space-y-1 text-right">
-        <div className="h-3 bg-[#F2F4F6] rounded w-16 animate-pulse" />
-        <div className="h-2.5 bg-[#F2F4F6] rounded w-14 animate-pulse" />
-      </div>
-    </div>
-  ));
-}
-
-function SkeletonInsightCard({ count = 3 }) {
-  return Array.from({ length: count }).map((_, i) => (
-    <div key={i} className="rounded-xl border border-[#F2F4F6] p-3 space-y-2 animate-pulse">
-      <div className="flex items-center gap-1.5">
-        <div className="h-3 bg-[#F2F4F6] rounded w-20" />
-        <div className="h-3 bg-[#F2F4F6] rounded w-10" />
-        <div className="h-3 bg-[#F2F4F6] rounded w-6 ml-auto" />
-      </div>
-      <div className="h-3 bg-[#F2F4F6] rounded" />
-      <div className="h-3 bg-[#F2F4F6] rounded w-4/5" />
-    </div>
-  ));
-}
-
-// ─── 인사이트 mock 데이터 (뉴스-무버 매칭 실패 시 fallback) ─
-// 뉴스 로딩 실패 또는 매칭 없을 때 항상 3개 표시
-const MOCK_INSIGHTS = [
-  {
-    id: 'mock-btc',
-    moverName: 'BTC', moverMarket: 'COIN', moverPct: null,
-    title: '비트코인 급등세 — 업비트 거래량 급증, 고래 매수 신호 포착',
-    timeAgo: '',
-    link: 'https://coindesk.com',
-    isMock: true,
-    signal: '강세',
-    desc: '업비트 거래량 급증, 고래 매수 신호',
-  },
-  {
-    id: 'mock-nvda',
-    moverName: 'NVDA', moverMarket: 'US', moverPct: null,
-    title: 'NVDA AI 모멘텀 지속 — AI 반도체 수요 지속 확대로 실적 전망 상향',
-    timeAgo: '',
-    link: 'https://finance.yahoo.com',
-    isMock: true,
-    signal: 'AI',
-    desc: 'AI 반도체 수요 지속 확대',
-  },
-  {
-    id: 'mock-samsung',
-    moverName: '삼성전자', moverMarket: 'KR', moverPct: null,
-    title: '삼성전자 외국인 순매수 — HBM4 납품 기대감에 외국인 3일 연속 순매수',
-    timeAgo: '',
-    link: 'https://news.naver.com',
-    isMock: true,
-    signal: '강세',
-    desc: '외국인 3일 연속 순매수',
-  },
-];
-
-// mock 인사이트 카드 (데이터 미확보 시 표시)
 const MockInsightCard = memo(function MockInsightCard({ mock }) {
   const badgePalette = { COIN: { bg: '#FFF4E6', color: '#FF9500' }, US: { bg: '#EDF4FF', color: '#3182F6' }, KR: { bg: '#FFF0F0', color: '#F04452' } };
   const badge = badgePalette[mock.moverMarket] || { bg: '#F2F4F6', color: '#8B95A1' };
@@ -403,7 +392,7 @@ const MockInsightCard = memo(function MockInsightCard({ mock }) {
       href={mock.link}
       target="_blank"
       rel="noopener noreferrer"
-      className="block rounded-xl border border-[#F2F4F6] p-3 hover:opacity-90 transition-opacity bg-[#FAFBFC]"
+      className="flex-shrink-0 w-[260px] block rounded-xl border border-[#F2F4F6] p-3 hover:opacity-90 transition-opacity bg-[#FAFBFC]"
     >
       <div className="flex items-center gap-1.5 mb-2">
         <span className="text-[12px] font-bold text-[#191F28]">{mock.moverName}</span>
@@ -417,12 +406,68 @@ const MockInsightCard = memo(function MockInsightCard({ mock }) {
   );
 });
 
-// ─── 급등/급락 탭 필터 버튼 ─────────────────────────────────
-const MOVER_FILTERS = [
+// ─── 스켈레톤 ─────────────────────────────────────────────────
+function SkeletonSurgeCard({ count = 5 }) {
+  return Array.from({ length: count }).map((_, i) => (
+    <div key={i} className="flex-shrink-0 w-[152px] rounded-2xl border border-[#F2F4F6] p-3.5 animate-pulse bg-white">
+      <div className="flex items-center justify-between mb-2.5">
+        <div className="w-8 h-8 rounded-full bg-[#F2F4F6]" />
+        <div className="w-8 h-4 rounded-full bg-[#F2F4F6]" />
+      </div>
+      <div className="h-3.5 bg-[#F2F4F6] rounded w-20 mb-1" />
+      <div className="h-3 bg-[#F2F4F6] rounded w-12 mb-2" />
+      <div className="h-4 bg-[#F2F4F6] rounded w-24 mb-1.5" />
+      <div className="h-5 bg-[#F2F4F6] rounded-full w-16 mb-2" />
+      <div className="h-7 bg-[#F2F4F6] rounded w-full" />
+    </div>
+  ));
+}
+
+function SkeletonHotRow({ count = 5 }) {
+  return Array.from({ length: count }).map((_, i) => (
+    <div key={i} className="flex items-center gap-2.5 px-4 py-2.5 animate-pulse">
+      <div className="w-4 h-3 bg-[#F2F4F6] rounded flex-shrink-0" />
+      <div className="w-6 h-6 rounded-full bg-[#F2F4F6] flex-shrink-0" />
+      <div className="flex-1 space-y-1">
+        <div className="h-3 bg-[#F2F4F6] rounded w-20" />
+        <div className="h-2.5 bg-[#F2F4F6] rounded w-12" />
+      </div>
+      <div className="space-y-1 text-right">
+        <div className="h-3 bg-[#F2F4F6] rounded w-14" />
+        <div className="h-2.5 bg-[#F2F4F6] rounded w-12" />
+      </div>
+    </div>
+  ));
+}
+
+// ─── mock 인사이트 데이터 ─────────────────────────────────────
+const MOCK_INSIGHTS = [
+  {
+    id: 'mock-btc',
+    moverName: 'BTC', moverMarket: 'COIN', moverPct: null,
+    title: '비트코인 급등세 — 업비트 거래량 급증, 고래 매수 신호 포착',
+    timeAgo: '', link: 'https://coindesk.com',
+  },
+  {
+    id: 'mock-nvda',
+    moverName: 'NVDA', moverMarket: 'US', moverPct: null,
+    title: 'NVDA AI 모멘텀 지속 — AI 반도체 수요 지속 확대로 실적 전망 상향',
+    timeAgo: '', link: 'https://finance.yahoo.com',
+  },
+  {
+    id: 'mock-samsung',
+    moverName: '삼성전자', moverMarket: 'KR', moverPct: null,
+    title: '삼성전자 외국인 순매수 — HBM4 납품 기대감에 외국인 3일 연속 순매수',
+    timeAgo: '', link: 'https://news.naver.com',
+  },
+];
+
+// ─── 급등 필터 탭 버튼 ──────────────────────────────────────
+const SURGE_FILTERS = [
   { id: 'all',  label: '전체' },
-  { id: 'KR',   label: 'KR'   },
-  { id: 'US',   label: 'US'   },
-  { id: 'COIN', label: 'COIN' },
+  { id: 'KR',   label: '🇰🇷 국내' },
+  { id: 'US',   label: '🇺🇸 미장' },
+  { id: 'COIN', label: '🪙 코인' },
 ];
 
 // ─── 메인 홈 대시보드 ────────────────────────────────────────
@@ -431,11 +476,16 @@ export default function HomeDashboard({
   krwRate = 1466, onItemClick,
 }) {
   const { data: allNews = [], isLoading: newsLoading } = useAllNewsQuery();
-
-  const [moverFilter, setMoverFilter] = useState('all');
+  const [surgeMarket, setSurgeMarket] = useState('all');
   const [coinCardOpen, setCoinCardOpen] = useState(true);
 
-  // 전체 시장 데이터 맵 (연관 종목 조회용)
+  // 마켓 태그 추가된 종목 리스트
+  const krItems   = useMemo(() => krStocks.map(s => ({ ...s, _market: 'KR'   })), [krStocks]);
+  const usItems   = useMemo(() => usStocks.map(s => ({ ...s, _market: 'US'   })), [usStocks]);
+  const coinItems = useMemo(() => coins.map(c   => ({ ...c, _market: 'COIN' })), [coins]);
+  const allItems  = useMemo(() => [...krItems, ...usItems, ...coinItems], [krItems, usItems, coinItems]);
+
+  // 데이터 맵 (연관 종목용)
   const dataMap = useMemo(() => {
     const map = {};
     for (const s of krStocks)  map[s.symbol] = s;
@@ -445,62 +495,222 @@ export default function HomeDashboard({
     return map;
   }, [krStocks, usStocks, coins]);
 
-  // 전 시장 통합 급등/급락
-  const { gainers, losers } = useMemo(() => {
-    const krItems   = krStocks.map(s => ({ ...s, _market: 'KR',   _pct: s.changePct ?? 0 }));
-    const usItems   = usStocks.map(s => ({ ...s, _market: 'US',   _pct: s.changePct ?? 0 }));
-    const coinItems = coins.map(c => ({ ...c, _market: 'COIN', _pct: c.change24h ?? 0 }));
-    const all = [...krItems, ...usItems, ...coinItems];
+  // ─── SECTION 1: 급등 스포트라이트 계산 ─────────────────────
+  const surgeItems = useMemo(() => {
+    let list = allItems;
+    if (surgeMarket === 'KR')   list = krItems;
+    else if (surgeMarket === 'US')   list = usItems;
+    else if (surgeMarket === 'COIN') list = coinItems;
 
-    const gainers = all.filter(i => i._pct > 0).sort((a, b) => b._pct - a._pct).slice(0, 10);
-    const losers  = all.filter(i => i._pct < 0).sort((a, b) => a._pct - b._pct).slice(0, 10);
+    const hot = list.filter(i => getPct(i) >= 2).sort((a, b) => getPct(b) - getPct(a));
+    return (hot.length >= 3 ? hot : [...list].sort((a, b) => getPct(b) - getPct(a))).slice(0, 5);
+  }, [allItems, krItems, usItems, coinItems, surgeMarket]);
 
-    return { gainers, losers };
-  }, [krStocks, usStocks, coins]);
+  // 급등 종목 존재 여부 (3% 이상)
+  const hasHotItems = useMemo(() => allItems.some(i => getPct(i) >= 3), [allItems]);
 
-  const filteredGainers = useMemo(
-    () => moverFilter === 'all' ? gainers : gainers.filter(i => i._market === moverFilter),
-    [gainers, moverFilter]
+  // ─── SECTION 3: 각 시장별 HOT TOP5 ────────────────────────
+  const krHot = useMemo(
+    () => [...krItems].sort((a, b) => getPct(b) - getPct(a)).slice(0, 5),
+    [krItems]
   );
-  const filteredLosers = useMemo(
-    () => moverFilter === 'all' ? losers : losers.filter(i => i._market === moverFilter),
-    [losers, moverFilter]
+  const usHot = useMemo(
+    () => [...usItems].sort((a, b) => getPct(b) - getPct(a)).slice(0, 5),
+    [usItems]
+  );
+  const coinHot = useMemo(
+    () => [...coinItems].sort((a, b) => getPct(b) - getPct(a)).slice(0, 5),
+    [coinItems]
   );
 
-  // 인사이트용 급등/급락 합산
-  const topMovers = useMemo(() => [...gainers, ...losers], [gainers, losers]);
+  // ─── SECTION 4: 인사이트 (뉴스 × 무버 매칭) ────────────────
+  const topMovers = useMemo(() => {
+    return [...allItems].sort((a, b) => Math.abs(getPct(b)) - Math.abs(getPct(a))).slice(0, 20);
+  }, [allItems]);
 
-  // 인사이트: 무버 + 뉴스 매칭 (최대 4개)
   const insights = useMemo(() => {
     if (!allNews.length || !topMovers.length) return [];
     return topMovers
       .map(mover => ({ mover, news: findRelatedNews(mover, allNews) }))
       .filter(({ news }) => news !== null)
-      .slice(0, 4);
+      .slice(0, 6);
   }, [topMovers, allNews]);
+
+  const hasData = krStocks.length > 0 || usStocks.length > 0 || coins.length > 0;
 
   const today = new Date().toLocaleDateString('ko-KR', {
     year: 'numeric', month: 'long', day: 'numeric', weekday: 'long',
   });
 
-  const hasData = krStocks.length > 0 || usStocks.length > 0 || coins.length > 0;
-
   return (
-    <div className="space-y-3">
-      {/* 상단: 날짜 + 실시간 표시 */}
+    <div className="space-y-4">
+
+      {/* ─── 상단 헤더 ─────────────────────────────────────── */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-[18px] font-bold text-[#191F28]">지금 핫한 것</h2>
+          <h2 className="text-[18px] font-bold text-[#191F28] leading-tight">지금 뭐가 움직이고 있어?</h2>
           <p className="text-[12px] text-[#8B95A1] mt-0.5">{today}</p>
         </div>
-        <div className="flex items-center gap-1.5 px-3 py-1.5 bg-white rounded-lg border border-[#F2F4F6]">
+        <div className="flex items-center gap-1.5 px-3 py-1.5 bg-white rounded-lg border border-[#F2F4F6] shadow-sm">
           <span className="w-1.5 h-1.5 rounded-full bg-[#2AC769] animate-pulse" />
-          <span className="text-[11px] text-[#6B7684] font-medium">실시간 업데이트</span>
+          <span className="text-[11px] text-[#6B7684] font-medium">실시간</span>
         </div>
       </div>
 
-      {/* ① 인사이트 카드 — 최상단 배치 (항상 표시: 로딩/실데이터/mock) */}
-      <div className="bg-white rounded-2xl overflow-hidden shadow-sm">
+      {/* ─── SECTION 1: 급등 스포트라이트 ─────────────────── */}
+      <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+        {/* 섹션 헤더 */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
+          <div className="flex items-center gap-2">
+            <span className="text-[14px]">🚀</span>
+            <span className="text-[14px] font-bold text-[#191F28]">지금 급등</span>
+            {hasHotItems && (
+              <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#FFF0F0] text-[#F04452] animate-pulse">
+                HOT
+              </span>
+            )}
+          </div>
+          {/* 시장 필터 탭 */}
+          <div className="flex items-center gap-1">
+            {SURGE_FILTERS.map(f => (
+              <button
+                key={f.id}
+                onClick={() => setSurgeMarket(f.id)}
+                className={`text-[10px] px-2 py-1 rounded-md font-semibold transition-colors flex-shrink-0 ${
+                  surgeMarket === f.id
+                    ? 'bg-[#191F28] text-white'
+                    : 'text-[#6B7684] hover:bg-[#F2F4F6]'
+                }`}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 급등 카드 가로 스크롤 */}
+        <div className="flex gap-3 overflow-x-auto p-4 no-scrollbar">
+          {!hasData
+            ? <SkeletonSurgeCard count={5} />
+            : surgeItems.map(item => (
+                <SurgeCard
+                  key={`surge-${item._market}-${item.id || item.symbol}`}
+                  item={item}
+                  krwRate={krwRate}
+                  onClick={onItemClick}
+                />
+              ))
+          }
+        </div>
+      </div>
+
+      {/* ─── SECTION 2: 시장 지수 compact 스트립 ─────────── */}
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-[12px] font-bold text-[#8B95A1] uppercase tracking-wide">시장 지수</span>
+          <div className="flex-1 h-px bg-[#F2F4F6]" />
+          {/* 환율 */}
+          <span className="text-[12px] font-bold text-[#191F28] tabular-nums font-mono">
+            ₩{(krwRate || 0).toLocaleString('ko-KR')}
+            <span className="text-[10px] font-normal text-[#B0B8C1] ml-1">USD/KRW</span>
+          </span>
+        </div>
+        <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
+          {indices.length > 0
+            ? indices.map(idx => <IndexStripItem key={idx.id} idx={idx} />)
+            : [1, 2, 3, 4, 5, 6].map(i => (
+                <div key={i} className="flex-shrink-0 h-9 w-28 rounded-xl bg-[#F2F4F6] animate-pulse" />
+              ))
+          }
+        </div>
+      </div>
+
+      {/* ─── SECTION 3: 3열 HOT 리스트 ───────────────────── */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {/* 국내 급등 */}
+        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13px]">🇰🇷</span>
+              <span className="text-[13px] font-bold text-[#191F28]">국내 급등</span>
+            </div>
+            <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#FFF0F0] text-[#F04452]">TOP 5</span>
+          </div>
+          <div className="py-1">
+            {!hasData
+              ? <SkeletonHotRow count={5} />
+              : krHot.length > 0
+                ? krHot.map((item, i) => (
+                    <HotRow
+                      key={`kr-hot-${item.symbol}`}
+                      item={item}
+                      rank={i + 1}
+                      krwRate={krwRate}
+                      onClick={onItemClick}
+                    />
+                  ))
+                : <div className="px-4 py-6 text-center text-[12px] text-[#B0B8C1]">데이터 로딩 중</div>
+            }
+          </div>
+        </div>
+
+        {/* 미장 급등 */}
+        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13px]">🇺🇸</span>
+              <span className="text-[13px] font-bold text-[#191F28]">미장 급등</span>
+            </div>
+            <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#3182F6]">TOP 5</span>
+          </div>
+          <div className="py-1">
+            {!hasData
+              ? <SkeletonHotRow count={5} />
+              : usHot.length > 0
+                ? usHot.map((item, i) => (
+                    <HotRow
+                      key={`us-hot-${item.symbol}`}
+                      item={item}
+                      rank={i + 1}
+                      krwRate={krwRate}
+                      onClick={onItemClick}
+                    />
+                  ))
+                : <div className="px-4 py-6 text-center text-[12px] text-[#B0B8C1]">데이터 로딩 중</div>
+            }
+          </div>
+        </div>
+
+        {/* 코인 급등 */}
+        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13px]">🪙</span>
+              <span className="text-[13px] font-bold text-[#191F28]">코인 급등</span>
+            </div>
+            <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#FFF4E6] text-[#FF9500]">TOP 5</span>
+          </div>
+          <div className="py-1">
+            {!hasData
+              ? <SkeletonHotRow count={5} />
+              : coinHot.length > 0
+                ? coinHot.map((item, i) => (
+                    <HotRow
+                      key={`coin-hot-${item.symbol}`}
+                      item={item}
+                      rank={i + 1}
+                      krwRate={krwRate}
+                      onClick={onItemClick}
+                    />
+                  ))
+                : <div className="px-4 py-6 text-center text-[12px] text-[#B0B8C1]">데이터 로딩 중</div>
+            }
+          </div>
+        </div>
+      </div>
+
+      {/* ─── SECTION 4: 인사이트 카드 (가로 스크롤) ─────── */}
+      <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
         <div className="flex items-center gap-2 px-4 py-3 border-b border-[#F2F4F6]">
           <span className="text-[14px]">💡</span>
           <span className="text-[14px] font-bold text-[#191F28]">인사이트</span>
@@ -509,10 +719,17 @@ export default function HomeDashboard({
           )}
           <span className="text-[11px] text-[#B0B8C1] ml-auto">급등종목 관련 뉴스</span>
         </div>
-        <div className="p-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
-          {/* 로딩 중: 스켈레톤 */}
-          {newsLoading && <SkeletonInsightCard count={4} />}
-          {/* 실제 인사이트 */}
+        <div className="flex gap-3 overflow-x-auto p-4 no-scrollbar">
+          {newsLoading && Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex-shrink-0 w-[260px] rounded-xl border border-[#F2F4F6] p-3 animate-pulse">
+              <div className="flex gap-1.5 mb-2">
+                <div className="h-3 bg-[#F2F4F6] rounded w-20" />
+                <div className="h-3 bg-[#F2F4F6] rounded w-10" />
+              </div>
+              <div className="h-3 bg-[#F2F4F6] rounded mb-1" />
+              <div className="h-3 bg-[#F2F4F6] rounded w-4/5" />
+            </div>
+          ))}
           {!newsLoading && insights.map(({ mover, news }) => (
             <InsightCard
               key={`insight-${mover._market}-${mover.id || mover.symbol}`}
@@ -521,95 +738,14 @@ export default function HomeDashboard({
               onMoverClick={onItemClick}
             />
           ))}
-          {/* 뉴스 매칭 없을 때 mock 카드 표시 (데이터 로딩 전까지) */}
           {!newsLoading && insights.length === 0 && MOCK_INSIGHTS.map(mock => (
             <MockInsightCard key={mock.id} mock={mock} />
           ))}
         </div>
       </div>
 
-      {/* ② 시장 맥락 바 (지수 미니칩) */}
-      <div className="flex items-center gap-2">
-        <span className="text-[13px] font-bold text-[#8B95A1]">시장 지수</span>
-      </div>
-      <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
-        {indices.length > 0
-          ? indices.map(idx => <IndexMiniChip key={idx.id} idx={idx} />)
-          : [1, 2, 3, 4, 5, 6].map(i => (
-            <div key={i} className="flex-shrink-0 bg-white rounded-xl px-3 py-2.5 w-36 h-12 animate-pulse border border-[#F2F4F6]" />
-          ))
-        }
-      </div>
-
-      {/* ③ 급등/급락 TOP10 + 탭 필터 + 인라인 관련종목 chip */}
-      <div className="flex items-center gap-1.5">
-        {MOVER_FILTERS.map(f => (
-          <button
-            key={f.id}
-            onClick={() => setMoverFilter(f.id)}
-            className={`text-[10px] px-2 py-1 rounded-md font-semibold transition-colors ${
-              moverFilter === f.id
-                ? 'bg-[#191F28] text-white'
-                : 'bg-[#F2F4F6] text-[#6B7684] hover:bg-[#E5E8EB]'
-            }`}
-          >
-            {f.label}
-          </button>
-        ))}
-      </div>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {/* 급등 섹션 */}
-        <div className="rounded-2xl p-4 shadow-sm" style={{ background: '#FFFAFA' }}>
-          <div className="flex items-center gap-2 mb-3">
-            <span className="text-[14px] font-bold text-[#F04452]">🔴 급등 TOP 10</span>
-            <span className="text-[11px] text-[#B0B8C1] ml-auto">
-              {moverFilter === 'all' ? '국내·해외·코인' : moverFilter}
-            </span>
-          </div>
-          {!hasData && <SkeletonRow count={5} />}
-          {hasData && filteredGainers.length === 0 && (
-            <div className="text-center py-6 text-[13px] text-[#B0B8C1]">해당 종목 없음</div>
-          )}
-          {hasData && filteredGainers.map((item, i) => (
-            <MoverRow
-              key={`gainer-${item._market}-${item.id || item.symbol}`}
-              item={item}
-              rank={i + 1}
-              krwRate={krwRate}
-              onClick={onItemClick}
-              dataMap={dataMap}
-            />
-          ))}
-        </div>
-
-        {/* 급락 섹션 */}
-        <div className="rounded-2xl p-4 shadow-sm" style={{ background: '#F4F8FF' }}>
-          <div className="flex items-center gap-2 mb-3">
-            <span className="text-[14px] font-bold text-[#1764ED]">🔵 급락 TOP 10</span>
-            <span className="text-[11px] text-[#B0B8C1] ml-auto">
-              {moverFilter === 'all' ? '국내·해외·코인' : moverFilter}
-            </span>
-          </div>
-          {!hasData && <SkeletonRow count={5} />}
-          {hasData && filteredLosers.length === 0 && (
-            <div className="text-center py-6 text-[13px] text-[#B0B8C1]">해당 종목 없음</div>
-          )}
-          {hasData && filteredLosers.map((item, i) => (
-            <MoverRow
-              key={`loser-${item._market}-${item.id || item.symbol}`}
-              item={item}
-              rank={i + 1}
-              krwRate={krwRate}
-              onClick={onItemClick}
-              dataMap={dataMap}
-            />
-          ))}
-        </div>
-      </div>
-
-      {/* ④ 코인 요약 카드 — 접기/펼치기 토글 */}
-      <div className="bg-white rounded-2xl overflow-hidden shadow-sm">
+      {/* ─── SECTION 5: 코인 시장 요약 (접기/펼치기) ─────── */}
+      <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
         <button
           onClick={() => setCoinCardOpen(prev => !prev)}
           className="w-full flex items-center gap-2 px-4 py-3.5 border-b border-[#F2F4F6] hover:bg-[#FAFBFC] transition-colors"

--- a/src/components/MarketSummaryBar.jsx
+++ b/src/components/MarketSummaryBar.jsx
@@ -1,4 +1,5 @@
-// 시장 지수 서머리 바
+// 시장 지수 서머리 바 — 개선
+// 환율 표시 개선, hover 효과, 장 오픈 상태 animate-pulse dot
 import { useMemo } from 'react';
 import { getKoreanMarketStatus, getUsMarketStatus } from '../utils/marketHours';
 
@@ -13,32 +14,51 @@ const INDEX_FLAG = {
   SPX: '🇺🇸', NDX: '🇺🇸', DJI: '🇺🇸', DXY: '🇺🇸',
 };
 
-function IndexItem({ idx }) {
+// 지수별 장 상태 매핑
+const INDEX_MARKET = {
+  KOSPI: 'kr', KOSDAQ: 'kr',
+  SPX: 'us', NDX: 'us', DJI: 'us', DXY: 'us',
+};
+
+function IndexItem({ idx, isOpen }) {
   const isUp   = (idx.changePct ?? 0) > 0;
   const isDown = (idx.changePct ?? 0) < 0;
   const flag   = INDEX_FLAG[idx.id] || '';
 
   return (
-    <div className="flex-shrink-0 px-5 border-r border-[#F2F4F6] last:border-0">
-      <div className="flex items-center gap-1 mb-1">
+    <div className="flex-shrink-0 flex items-center gap-3 px-5 border-r border-[#F2F4F6] last:border-0 cursor-default hover:bg-[#F7F8FA] transition-colors py-1 rounded-lg group">
+      {/* 장 오픈 상태 dot */}
+      <div className="flex items-center gap-1.5">
+        <span
+          className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+            isOpen ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'
+          }`}
+        />
         <span className="text-[12px]">{flag}</span>
         <span className="text-[11px] text-[#8B95A1] font-medium">{idx.name}</span>
+        {idx.isDelayed && (
+          <span className="text-[9px] text-[#B0B8C1] bg-[#F2F4F6] px-1 rounded">지연</span>
+        )}
       </div>
-      <div className="flex items-baseline gap-2">
-        <span className="text-[17px] font-bold text-[#191F28] tabular-nums font-mono">
-          {fmt(idx.value, idx.id === 'DXY' ? 2 : 2)}
-        </span>
-        <span className={`text-[12px] font-bold tabular-nums font-mono ${
-          isUp ? 'text-[#F04452]' : isDown ? 'text-[#1764ED]' : 'text-[#8B95A1]'
-        }`}>
-          {isUp ? '▲' : isDown ? '▼' : '—'}{Math.abs(idx.changePct ?? 0).toFixed(2)}%
-        </span>
-      </div>
-      {idx.change != null && (
-        <div className={`text-[11px] tabular-nums font-mono ${isUp ? 'text-[#F04452]' : isDown ? 'text-[#1764ED]' : 'text-[#8B95A1]'}`}>
-          {isUp ? '+' : ''}{fmt(idx.change, idx.id === 'DXY' ? 2 : 2)}
+      <div>
+        <div className="flex items-baseline gap-2">
+          <span className="text-[16px] font-bold text-[#191F28] tabular-nums font-mono">
+            {fmt(idx.value, 2)}
+          </span>
+          <span className={`text-[12px] font-bold tabular-nums font-mono ${
+            isUp ? 'text-[#F04452]' : isDown ? 'text-[#1764ED]' : 'text-[#8B95A1]'
+          }`}>
+            {isUp ? '▲' : isDown ? '▼' : '—'}{Math.abs(idx.changePct ?? 0).toFixed(2)}%
+          </span>
         </div>
-      )}
+        {idx.change != null && (
+          <div className={`text-[11px] tabular-nums font-mono ${
+            isUp ? 'text-[#F04452]' : isDown ? 'text-[#1764ED]' : 'text-[#8B95A1]'
+          }`}>
+            {isUp ? '+' : ''}{fmt(idx.change, 2)}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -62,8 +82,8 @@ export default function MarketSummaryBar({ indices = [], krwRate = 1466, loading
   }
 
   return (
-    <div className="bg-white rounded-2xl flex items-stretch overflow-x-auto no-scrollbar">
-      {/* 장 상태 */}
+    <div className="bg-white rounded-2xl flex items-stretch overflow-x-auto no-scrollbar border border-[#F2F4F6] shadow-sm">
+      {/* 장 운영 상태 */}
       <div className="flex-shrink-0 flex flex-col justify-center gap-1.5 px-4 py-3 border-r border-[#F2F4F6]">
         <div className="flex items-center gap-1.5">
           <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${kr.status === 'open' ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
@@ -78,17 +98,22 @@ export default function MarketSummaryBar({ indices = [], krwRate = 1466, loading
       </div>
 
       {/* 지수들 */}
-      <div className="flex items-center py-3">
-        {displayIndices.map(idx => (
-          <IndexItem key={idx.id} idx={idx} />
-        ))}
+      <div className="flex items-center py-2 px-1">
+        {displayIndices.map(idx => {
+          const market = INDEX_MARKET[idx.id];
+          const isOpen = market === 'kr' ? kr.status === 'open' : market === 'us' ? us.status === 'open' : false;
+          return <IndexItem key={idx.id} idx={idx} isOpen={isOpen} />;
+        })}
       </div>
 
-      {/* 환율 */}
+      {/* 환율 — 개선: ₩ 1,466 형태 */}
       <div className="flex-shrink-0 flex flex-col justify-center px-5 py-3 border-l border-[#F2F4F6] ml-auto">
-        <div className="text-[11px] text-[#8B95A1] font-medium mb-1">💱 USD/KRW</div>
+        <div className="flex items-center gap-1 mb-1">
+          <span className="text-[11px] text-[#8B95A1] font-medium">💱</span>
+          <span className="text-[10px] text-[#8B95A1] font-medium">USD/KRW</span>
+        </div>
         <div className="text-[17px] font-bold text-[#191F28] tabular-nums font-mono">
-          ₩{krwRate.toLocaleString('ko-KR')}
+          ₩{' '}{(krwRate || 0).toLocaleString('ko-KR')}
         </div>
       </div>
     </div>

--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -1,7 +1,12 @@
+// 급등 ticker 배너 — 상단 sticky
+// 급등(>=3%) 종목만 표시, 없으면 상위 5개
+// 급등 있을 때: 어두운 배경 + 빨간 강조
+// 없을 때: 중립 배경
 import { useMemo } from 'react';
 
-export default function SurgeBanner({ stocks = [], coins = [] }) {
-  const items = useMemo(() => {
+export default function SurgeBanner({ stocks = [], coins = [], onClick }) {
+  // 급등 종목 선별 (>=3%), 없으면 상위 5개
+  const { items, hasHot } = useMemo(() => {
     const all = [
       ...stocks.map(s => ({
         name:   s.name || s.symbol,
@@ -9,6 +14,7 @@ export default function SurgeBanner({ stocks = [], coins = [] }) {
         pct:    s.changePct ?? 0,
         image:  null,
         market: s.market,
+        _raw:   s,
       })),
       ...coins.map(c => ({
         name:   c.name,
@@ -16,32 +22,84 @@ export default function SurgeBanner({ stocks = [], coins = [] }) {
         pct:    c.change24h ?? 0,
         image:  c.image || null,
         market: 'coin',
+        _raw:   c,
       })),
-    ].filter(i => i.pct >= 3)
-     .sort((a, b) => b.pct - a.pct)
-     .slice(0, 20);
-    return [...all, ...all];
+    ].sort((a, b) => b.pct - a.pct);
+
+    const hot = all.filter(i => i.pct >= 3);
+    const hasHot = hot.length > 0;
+    // 급등 있으면 급등만, 없으면 상위 5개
+    const base = hasHot ? hot : all.slice(0, 5);
+    // 무한 스크롤 효과를 위해 2배 복제
+    return { items: [...base, ...base], hasHot };
   }, [stocks, coins]);
 
   if (!items.length) return null;
-  const dur = Math.max(28, items.length * 2);
+
+  const dur = Math.max(24, items.length * 1.8);
 
   return (
-    <div style={{ background: '#0D0D0D', height: '32px', overflow: 'hidden' }} className="flex items-center ticker-wrap">
+    <div
+      style={{
+        background: hasHot ? '#0D0D0D' : '#18181B',
+        height: '32px',
+        overflow: 'hidden',
+      }}
+      className="flex items-center ticker-wrap"
+    >
       {/* 라벨 */}
-      <div className="flex-shrink-0 px-3 border-r border-white/10 flex items-center gap-1.5 h-full">
-        <span className="w-1.5 h-1.5 rounded-full bg-[#FF6B77] animate-pulse" />
-        <span className="text-[10px] font-bold text-white/40 tracking-widest uppercase">급등</span>
+      <div
+        className="flex-shrink-0 px-3 border-r flex items-center gap-1.5 h-full"
+        style={{ borderColor: hasHot ? 'rgba(240,68,82,0.3)' : 'rgba(255,255,255,0.1)' }}
+      >
+        <span
+          className="w-1.5 h-1.5 rounded-full animate-pulse"
+          style={{ background: hasHot ? '#FF6B77' : '#6B7280' }}
+        />
+        <span
+          className="text-[10px] font-bold tracking-widest uppercase"
+          style={{ color: hasHot ? 'rgba(255,107,119,0.9)' : 'rgba(255,255,255,0.35)' }}
+        >
+          {hasHot ? '🔥 급등' : '시세'}
+        </span>
       </div>
+
+      {/* ticker track */}
       <div className="ticker-track" style={{ '--dur': `${dur}s` }}>
         {items.map((item, i) => (
-          <span key={i} className="inline-flex items-center gap-2 px-4 text-[11px] font-medium">
-            <span className="font-bold" style={{ color: 'rgba(255,255,255,0.85)' }}>{item.symbol}</span>
-            <span style={{ color: 'rgba(255,255,255,0.45)' }}>{item.name}</span>
-            <span className="font-bold tabular-nums" style={{ color: '#FF6B77' }}>
-              ▲{item.pct.toFixed(2)}%
+          <span
+            key={i}
+            className="inline-flex items-center gap-2 px-4 text-[11px] font-medium cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => item._raw && onClick?.(item._raw)}
+          >
+            {/* 심볼 */}
+            <span
+              className="font-bold"
+              style={{ color: hasHot ? 'rgba(255,255,255,0.9)' : 'rgba(255,255,255,0.7)' }}
+            >
+              {item.symbol}
             </span>
-            <span style={{ color: 'rgba(255,255,255,0.1)' }}>·</span>
+            {/* 이름 */}
+            <span style={{ color: 'rgba(255,255,255,0.4)' }}>{item.name}</span>
+            {/* 등락률 배지 */}
+            <span
+              className="font-bold tabular-nums px-1.5 py-0.5 rounded-full text-[10px]"
+              style={{
+                background: item.pct >= 3
+                  ? 'rgba(240,68,82,0.2)'
+                  : item.pct > 0
+                  ? 'rgba(42,199,105,0.15)'
+                  : 'rgba(255,255,255,0.08)',
+                color: item.pct >= 3
+                  ? '#FF6B77'
+                  : item.pct > 0
+                  ? '#2AC769'
+                  : 'rgba(255,255,255,0.45)',
+              }}
+            >
+              {item.pct > 0 ? '▲' : item.pct < 0 ? '▼' : '—'}{Math.abs(item.pct).toFixed(2)}%
+            </span>
+            <span style={{ color: 'rgba(255,255,255,0.08)' }}>·</span>
           </span>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- 급등 스포트라이트 (전체/국내/미장/코인 필터, 가로 스크롤 카드)
- 시장 지수 compact 스트립 + 환율 인라인
- 3열 HOT 리스트 (국내/미장/코인 각 TOP5)
- 인사이트 카드 가로 스크롤 compact화
- SurgeBanner: 급등 종목 클릭 시 차트 패널 오픈
- MarketSummaryBar: 장 오픈 상태 pulse dot
- Header: 이모지 탭 + 급등 탭 🔥 뱃지

🤖 Generated with [Claude Code](https://claude.com/claude-code)