### PR TITLE
feat: 급등/급락 브라우저 알림 (Job 2 강화)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import { fetchCoins, fetchCoinsUpbitOnly, fetchExchangeRate } from './api/coins'
 import { fetchUsStocksBatch, fetchKoreanStocksBatch, fetchIndices } from './api/stocks';
 import { getKoreanMarketStatus, getUsMarketStatus } from './utils/marketHours';
 import { subscribeCoinPrices, unsubscribeCoinPrices } from './api/coinWs';
+import { requestNotificationPermission, checkAndAlertBatch } from './utils/priceAlert';
 
 const US_SYMBOLS   = US_STOCKS_INITIAL.map(s => s.symbol);
 const COIN_SYMBOLS = COINS_INITIAL.map(c => c.symbol);
@@ -64,7 +65,13 @@ export default function App() {
       setCoins(prev => {
         if (!prev.length) return prev;
         fetchCoinsUpbitOnly(prev, rate)
-          .then(data => { if (data.length) setCoins(data); })
+          .then(data => {
+            if (data.length) {
+              setCoins(data);
+              // 코인 급등/급락 브라우저 알림 체크 (폴링에서만, WS 틱 아님)
+              checkAndAlertBatch(data, 'coin');
+            }
+          })
           .catch(() => {});
         return prev;
       });
@@ -96,6 +103,7 @@ export default function App() {
           const u = data.find(d => d.symbol === s.symbol);
           return u?.price ? { ...s, ...u, sparkline: u.sparkline?.length ? u.sparkline : s.sparkline } : s;
         }));
+        checkAndAlertBatch(data, 'us');
       }
     } catch (e) { console.warn('미장 갱신 실패:', e.message); }
   }, []);
@@ -109,6 +117,7 @@ export default function App() {
           const u = data.find(d => d.symbol === s.symbol);
           return u?.price ? { ...s, ...u, sparkline: [...s.sparkline.slice(1), u.price] } : s;
         }));
+        checkAndAlertBatch(data, 'kr');
       }
     } catch (e) { console.warn('국장 갱신 실패:', e.message); }
   }, []);
@@ -167,6 +176,9 @@ export default function App() {
 
   // 환율 변경 시 ref 동기화 (WS 핸들러에서 클로저 없이 사용)
   useEffect(() => { krwRateRef.current = krwRate; }, [krwRate]);
+
+  // ── 브라우저 알림 권한 요청 (초기 1회) ──────────────────────────
+  useEffect(() => { requestNotificationPermission(); }, []);
 
   // ── Upbit WebSocket 코인 가격 실시간 스트림 ─────────────────────
   // 폴링(10초)과 병행 — WS가 연결되면 <1초 단위 가격 갱신, 끊기면 자동 재연결

--- a/src/utils/priceAlert.js
+++ b/src/utils/priceAlert.js
@@ -1,0 +1,88 @@
+// ─── 가격 알림 유틸 ──────────────────────────────────────────
+// 브라우저 Notification API 활용
+// - 등락률 임계값 초과 시 1회 알림 (스팸 방지: 종목당 5분 쿨다운)
+// - 권한 미부여 시 조용히 무시
+
+const SURGE_THRESHOLD  = 3;   // +3% 이상 → 급등 알림
+const DROP_THRESHOLD   = -3;  // -3% 이하 → 급락 알림 (선택적)
+const COOLDOWN_MS      = 5 * 60 * 1000; // 5분 쿨다운
+
+// 종목별 마지막 알림 시각 캐시
+const lastAlertTime = new Map();
+
+// ─── 권한 요청 ─────────────────────────────────────────────
+export async function requestNotificationPermission() {
+  if (!('Notification' in window)) return false;
+  if (Notification.permission === 'granted') return true;
+  if (Notification.permission === 'denied') return false;
+  const result = await Notification.requestPermission();
+  return result === 'granted';
+}
+
+export function getNotificationPermission() {
+  if (!('Notification' in window)) return 'unsupported';
+  return Notification.permission;
+}
+
+// ─── 단일 알림 발송 ─────────────────────────────────────────
+function sendAlert(title, body, { tag, icon } = {}) {
+  if (!('Notification' in window)) return;
+  if (Notification.permission !== 'granted') return;
+  try {
+    const n = new Notification(title, {
+      body,
+      tag:  tag  ?? 'price-alert',
+      icon: icon ?? '/favicon.ico',
+      silent: false,
+    });
+    // 5초 후 자동 닫기
+    setTimeout(() => n.close(), 5000);
+  } catch {}
+}
+
+// ─── 종목 알림 체크 ─────────────────────────────────────────
+// item: { symbol, name, changePct, price, priceKrw? }
+// type: 'kr' | 'us' | 'coin'
+export function checkAndAlert(item, type) {
+  if (Notification.permission !== 'granted') return;
+
+  const key  = `${type}:${item.symbol}`;
+  const now  = Date.now();
+  const last = lastAlertTime.get(key) ?? 0;
+  if (now - last < COOLDOWN_MS) return; // 쿨다운 중
+
+  const pct = item.changePct ?? item.change24h ?? 0;
+  if (Math.abs(pct) < SURGE_THRESHOLD) return; // 임계값 미달
+
+  const dir  = pct > 0 ? '🔴 급등' : '🔵 급락';
+  const sign = pct > 0 ? '+' : '';
+  const name = item.name ?? item.symbol;
+
+  let priceStr = '';
+  if (type === 'kr') {
+    priceStr = `₩${(item.price ?? 0).toLocaleString()}`;
+  } else if (type === 'coin' && item.priceKrw) {
+    priceStr = `₩${Math.round(item.priceKrw).toLocaleString()}`;
+  } else {
+    priceStr = `$${(item.price ?? 0).toLocaleString()}`;
+  }
+
+  sendAlert(
+    `${dir} ${name}  ${sign}${pct.toFixed(2)}%`,
+    `현재가 ${priceStr}`,
+    { tag: key },
+  );
+  lastAlertTime.set(key, now);
+}
+
+// ─── 배치 체크 ───────────────────────────────────────────────
+// items 배열 전체를 체크 (폴링 갱신 후 호출)
+export function checkAndAlertBatch(items, type) {
+  if (Notification.permission !== 'granted') return;
+  items.forEach(item => checkAndAlert(item, type));
+}
+
+// ─── 쿨다운 초기화 (테스트용) ────────────────────────────────
+export function clearAlertCooldowns() {
+  lastAlertTime.clear();
+}


### PR DESCRIPTION
## Summary
- `src/utils/priceAlert.js` 신규: 브라우저 Notification API 기반 가격 알림 유틸
- 등락률 ±3% 임계값 초과 시 알림 발송
- 종목당 5분 쿨다운으로 스팸 방지
- 앱 최초 로드 시 알림 권한 자동 요청
- 국장/미장 30초 폴링 + 코인 10초 폴링 완료 후 배치 체크 (WS 틱 아닌 폴링에서만)

## Why
PRD v4 고려사항: "등락률 임계값 브라우저 알림" — Job 2("급등 종목 남들보다 10초 먼저 캐치") 직결

🤖 Generated with [Claude Code](https://claude.com/claude-code)