### PR TITLE
fix: 국장 127종목 전체 수신 — 한투 배치 분할 + Naver serverless fallback

### DIFF
--- a/api/naver-price.js
+++ b/api/naver-price.js
@@ -1,0 +1,48 @@
+// 네이버 증권 모바일 API — 국장 가격 서버사이드 프록시
+// 클라이언트에서 직접 호출 불가(CORS) → Vercel serverless 경유
+//
+// 요청: GET /api/naver-price?symbols=005930,000660
+// 응답: { data: [ { symbol, price, change, changePct, volume } ] }
+
+const NAVER_BASE = 'https://m.stock.naver.com/api/stock';
+
+async function fetchNaverSingle(symbol) {
+  const res = await fetch(`${NAVER_BASE}/${symbol}/basic`, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+      'Referer': 'https://m.stock.naver.com/',
+    },
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) throw new Error(`${symbol}: HTTP ${res.status}`);
+  const data = await res.json();
+
+  const toNum = s => parseFloat((s || '').toString().replace(/,/g, '')) || 0;
+  const price     = toNum(data.closePrice);
+  const change    = toNum(data.compareToPreviousClosePrice);
+  const changePct = toNum(data.fluctuationsRatio);
+  const volume    = toNum(data.accumulatedTradingVolume);
+
+  if (!price) throw new Error(`${symbol}: 가격 없음`);
+  return { symbol, price, change, changePct, volume };
+}
+
+export default async function handler(req, res) {
+  const symbols = (req.query.symbols || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => /^\d{6}$/.test(s))
+    .slice(0, 30);
+
+  if (!symbols.length) {
+    return res.status(400).json({ error: 'symbols required' });
+  }
+
+  const settled = await Promise.allSettled(symbols.map(fetchNaverSingle));
+  const data    = settled.filter(r => r.status === 'fulfilled').map(r => r.value);
+  const errors  = settled.filter(r => r.status === 'rejected' ).map(r => r.reason?.message);
+
+  // 30초 캐시
+  res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate=10');
+  res.json({ data, errors: errors.length ? errors : undefined });
+}

--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -103,56 +103,75 @@ export async function fetchUsStocksBatch(symbols) {
   return settled.filter(r => r.status === 'fulfilled').map(r => r.value);
 }
 
-// ─── Naver Finance 모바일 API (한국 주식) ────────────────────
-async function fetchNaverSingle(symbol) {
-  const url  = `https://m.stock.naver.com/api/stock/${symbol}/basic`;
-  const data = await proxyFetch(url);
-  // 파일 상단 toNum 재사용 (shadowing 제거)
+// ─── Naver Finance (Vercel serverless 프록시) ─────────────────
+// allorigins는 520 오류로 사용 불가 → /api/naver-price 서버사이드 경유
+const NAVER_BATCH = 25;
 
-  const price     = toNum(data.closePrice);
-  const change    = toNum(data.compareToPreviousClosePrice);
-  const changePct = toNum(data.fluctuationsRatio);
-  const volume    = toNum(data.accumulatedTradingVolume);
+async function fetchNaverBatch(stocks) {
+  const symbols = stocks.map(s => s.symbol);
+  const results = [];
 
-  if (!price) throw new Error(`${symbol}: no price`);
-  return { symbol, price, change, changePct, volume };
+  for (let i = 0; i < symbols.length; i += NAVER_BATCH) {
+    const chunk = symbols.slice(i, i + NAVER_BATCH);
+    const res = await fetch(
+      `/api/naver-price?symbols=${chunk.join(',')}`,
+      { signal: AbortSignal.timeout(10000) }
+    );
+    if (!res.ok) throw new Error(`Naver 프록시 ${res.status}`);
+    const json = await res.json();
+    if (Array.isArray(json.data)) results.push(...json.data);
+    if (i + NAVER_BATCH < symbols.length) {
+      await new Promise(r => setTimeout(r, 100));
+    }
+  }
+  return results;
 }
 
 // ─── 한국투자증권 Open API (1순위 — 실시간 정확 데이터) ─────────
 // Vercel serverless /api/hantoo-price 프록시 경유
-// 키 미설정 또는 실패 시 503/500 → fallback으로 전환
+// 서버 측 20개 제한 → 클라이언트에서 18개씩 배치 분할 후 순차 요청
+// KIS API 20 TPS 보호: 배치 간 50ms 딜레이
+const HANTOO_BATCH = 18;
+
 async function fetchKoreanStocksHantoo(stocks) {
-  const symbols = stocks.map(s => s.symbol).join(',');
-  const res = await fetch(
-    `/api/hantoo-price?symbols=${symbols}`,
-    { signal: AbortSignal.timeout(10000) }
-  );
-  // 키 미설정(503) 또는 서버 오류(500) → fallback
-  if (!res.ok) throw new Error(`한투 프록시 ${res.status}`);
-  const json = await res.json();
-  if (!Array.isArray(json.data) || !json.data.length) throw new Error('한투: 데이터 없음');
-  return json.data;
+  const symbols = stocks.map(s => s.symbol);
+  const results = [];
+
+  for (let i = 0; i < symbols.length; i += HANTOO_BATCH) {
+    const chunk = symbols.slice(i, i + HANTOO_BATCH);
+    const res = await fetch(
+      `/api/hantoo-price?symbols=${chunk.join(',')}`,
+      { signal: AbortSignal.timeout(10000) }
+    );
+    // 키 미설정(503) 또는 서버 오류(500) → fallback
+    if (!res.ok) throw new Error(`한투 프록시 ${res.status}`);
+    const json = await res.json();
+    if (Array.isArray(json.data)) results.push(...json.data);
+    // 배치 간 딜레이 (마지막 배치 제외)
+    if (i + HANTOO_BATCH < symbols.length) {
+      await new Promise(r => setTimeout(r, 50));
+    }
+  }
+
+  if (!results.length) throw new Error('한투: 데이터 없음');
+  return results;
 }
 
 // ─── 한국 주식 배치 ────────────────────────────────────────────
 export async function fetchKoreanStocksBatch(stocks) {
   // 1) 한국투자증권 Open API (실시간, 가장 정확)
+  // 배치 분할로 127개 전체 커버 — 10% 이상 성공 시 채택 (부분 실패 허용)
   try {
     const data = await fetchKoreanStocksHantoo(stocks);
-    if (data.length >= stocks.length * 0.5) return data;
+    if (data.length >= stocks.length * 0.1) return data;
   } catch (e) {
     console.warn('[한투 시세] fallback:', e.message);
   }
 
-  // 2) Naver Finance (한투 실패 시 fallback)
+  // 2) Naver Finance via Vercel serverless (한투 실패 시 fallback)
   try {
-    const results = await Promise.allSettled(
-      stocks.map(s => fetchNaverSingle(s.symbol))
-    );
-    const valid = results
-      .filter(r => r.status === 'fulfilled' && r.value.price > 0)
-      .map(r => r.value);
-    if (valid.length >= stocks.length * 0.5) return valid;
+    const valid = await fetchNaverBatch(stocks);
+    if (valid.length >= stocks.length * 0.1) return valid;
   } catch {}
 
   // 3) Yahoo Finance .KS via proxy


### PR DESCRIPTION
## 근본 원인
`hantoo-price.js` 서버 측 `slice(0, 20)` 제한으로 127개 심볼 중 20개만 반환.
클라이언트 임계값 체크 `20 >= 127 * 0.5 = 63.5` → FALSE → 한투 결과 버림 → 고장난 allorigins fallback 시도.

## 수정 내용
- `fetchKoreanStocksHantoo`: 18개씩 배치 분할, 순차 요청 (KIS 20 TPS 보호)
  - 127개 → 7개 배치 × ~300ms = 약 2.2초 완료
- 임계값 `0.5 → 0.1` (부분 성공도 수용)
- Naver fallback: allorigins 직접 호출 → `/api/naver-price` serverless 프록시로 교체
  - allorigins가 Naver Finance URL에 HTTP 520 반환으로 완전 고장
  - 서버사이드에서 User-Agent + Referer 헤더로 정상 요청

## 예상 효과
- 장 중: 127종목 전부 한투 실시간 가격 수신
- 한투 실패 시: Naver Finance serverless로 정상 fallback