### PR TITLE
feat: 차트 분봉 + 전역검색 + 고래/뉴스 품질 강화

### DIFF
--- a/api/chart-proxy.js
+++ b/api/chart-proxy.js
@@ -1,11 +1,13 @@
 // api/chart-proxy.js — Yahoo Finance 차트 데이터 Vercel 프록시
 // CORS 우회 + 서버사이드 취득으로 allorigins 불안정 문제 해소
+// interval 파라미터 추가로 분봉/시봉/일봉/주봉/월봉 지원
 export const config = { runtime: 'edge' };
 
 export default async function handler(req) {
   const { searchParams } = new URL(req.url);
-  const symbol = searchParams.get('symbol');
-  const range  = searchParams.get('range') || '1mo';
+  const symbol   = searchParams.get('symbol');
+  const range    = searchParams.get('range')    || '1mo';
+  const interval = searchParams.get('interval') || '1d';
 
   if (!symbol) {
     return new Response(JSON.stringify({ error: 'symbol required' }), {
@@ -14,7 +16,7 @@ export default async function handler(req) {
     });
   }
 
-  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=${range}`;
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=${interval}&range=${range}`;
 
   try {
     const res = await fetch(url, {
@@ -28,10 +30,13 @@ export default async function handler(req) {
     if (!res.ok) throw new Error(`Yahoo ${res.status}`);
     const data = await res.json();
 
+    // 분봉/시봉은 캐시 짧게 (30초), 일봉 이상은 60초
+    const isIntraday = ['5m','15m','30m','60m','90m','1h'].includes(interval);
+
     return new Response(JSON.stringify(data), {
       headers: {
         'Content-Type': 'application/json',
-        'Cache-Control': 'public, s-maxage=60',
+        'Cache-Control': `public, s-maxage=${isIntraday ? 30 : 60}`,
         'Access-Control-Allow-Origin': '*',
       },
     });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import WatchlistTable from './components/WatchlistTable';
 import BreakingNewsPanel from './components/BreakingNewsPanel';
 import ChartSidePanel from './components/ChartSidePanel';
 import HomeDashboard from './components/HomeDashboard';
+import GlobalSearch from './components/GlobalSearch';
 
 import { KOREAN_STOCKS, US_STOCKS_INITIAL, COINS_INITIAL, ETF_DATA, INDICES_INITIAL } from './data/mock';
 import { fetchCoins, fetchCoinsUpbitOnly, fetchExchangeRate } from './api/coins';
@@ -52,6 +53,7 @@ export default function App() {
   const [lastUpdated, setLastUpdated]     = useState(null);
   const [loading, setLoading]             = useState(false);
   const [selectedItem, setSelectedItem]   = useState(null);
+  const [searchOpen, setSearchOpen]       = useState(false);
   const loadingRef  = useRef(false);
   const krwRateRef  = useRef(1466); // WS 핸들러에서 클로저 없이 최신 환율 참조
 
@@ -180,6 +182,18 @@ export default function App() {
   // ── 브라우저 알림 권한 요청 (초기 1회) ──────────────────────────
   useEffect(() => { requestNotificationPermission(); }, []);
 
+  // ── 전역 종목 검색: `/` 키 → 검색 모달 ─────────────────────────
+  useEffect(() => {
+    const onKey = e => {
+      // 입력 필드 포커스 중이면 무시 (검색창 자체 입력 방해하지 않도록)
+      if (e.key !== '/' || e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+      e.preventDefault();
+      setSearchOpen(true);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, []);
+
   // ── Upbit WebSocket 코인 가격 실시간 스트림 ─────────────────────
   // 폴링(10초)과 병행 — WS가 연결되면 <1초 단위 가격 갱신, 끊기면 자동 재연결
   useEffect(() => {
@@ -298,6 +312,19 @@ export default function App() {
           onClose={() => setSelectedItem(null)}
           onRelatedClick={setSelectedItem}
           allData={allData}
+        />
+      )}
+
+      {/* 전역 종목 검색 모달 — `/` 키로 열기 */}
+      {searchOpen && (
+        <GlobalSearch
+          krStocks={krStocks}
+          usStocks={usStocks}
+          coins={coins}
+          etfs={ETF_ITEMS}
+          krwRate={krwRate}
+          onSelect={setSelectedItem}
+          onClose={() => setSearchOpen(false)}
         />
       )}
     </div>

--- a/src/api/chart.js
+++ b/src/api/chart.js
@@ -1,48 +1,125 @@
 // 캔들차트 OHLCV 데이터
-// corsproxy.io 제거 — allorigins 단일 프록시 사용 (verified working)
+// 주식: Yahoo Finance via Vercel /api/chart-proxy (분봉/시봉/일봉/주봉/월봉)
+// 코인: Upbit REST API (분봉/시봉/일봉/주봉/월봉) — CORS 허용, 무료
 
-async function fetchWithProxy(targetUrl) {
-  const encoded = encodeURIComponent(targetUrl);
+// ─── 기간 설정 ────────────────────────────────────────────────
+// interval: Yahoo Finance / Upbit candle type
+// range: Yahoo Finance range 파라미터
+// coinType: Upbit candles/{type} 경로
+// coinCount: Upbit 캔들 수 (최대 200)
+// isIntraday: true면 time = Unix seconds, false면 'YYYY-MM-DD'
+export const PERIOD_CONFIG = {
+  '5분':   { interval: '5m',   range: '1d',   coinType: 'minutes/5',   coinCount: 200, isIntraday: true  },
+  '15분':  { interval: '15m',  range: '5d',   coinType: 'minutes/15',  coinCount: 200, isIntraday: true  },
+  '30분':  { interval: '30m',  range: '5d',   coinType: 'minutes/30',  coinCount: 200, isIntraday: true  },
+  '1시간': { interval: '60m',  range: '1mo',  coinType: 'minutes/60',  coinCount: 200, isIntraday: true  },
+  '4시간': { interval: '90m',  range: '1mo',  coinType: 'minutes/240', coinCount: 200, isIntraday: true  },
+  '일':    { interval: '1d',   range: '3mo',  coinType: 'days',        coinCount: 200, isIntraday: false },
+  '주':    { interval: '1wk',  range: '1y',   coinType: 'weeks',       coinCount: 52,  isIntraday: false },
+  '월':    { interval: '1mo',  range: '5y',   coinType: 'months',      coinCount: 24,  isIntraday: false },
+};
 
-  // allorigins /get (primary)
-  try {
-    const res = await fetch(
-      `https://api.allorigins.win/get?url=${encoded}`,
-      { signal: AbortSignal.timeout(8000) }
-    );
-    if (res.ok) {
-      const json = await res.json();
-      if (json.contents) return JSON.parse(json.contents);
-    }
-  } catch {}
-
-  // allorigins /raw (fallback)
-  try {
-    const res = await fetch(
-      `https://api.allorigins.win/raw?url=${encoded}`,
-      { signal: AbortSignal.timeout(8000) }
-    );
-    if (res.ok) return res.json();
-  } catch {}
-
-  throw new Error('프록시 실패');
-}
-
-// 캔들 데이터 정제 — null 제거 + 날짜 중복 제거 (lightweight-charts setData 오류 방지)
+// ─── 캔들 데이터 정제 ────────────────────────────────────────
 function cleanCandles(candles) {
   const seen = new Set();
   return candles
-    .filter(c => c.time && c.open != null && c.close != null && c.high != null && c.low != null)
+    .filter(c => c.time != null && c.open != null && c.close != null && c.high != null && c.low != null)
     .filter(c => {
-      if (seen.has(c.time)) return false;
-      seen.add(c.time);
+      const key = c.time;
+      if (seen.has(key)) return false;
+      seen.add(key);
       return true;
     })
-    .sort((a, b) => a.time.localeCompare(b.time));
+    .sort((a, b) => {
+      if (typeof a.time === 'number') return a.time - b.time;
+      return String(a.time).localeCompare(String(b.time));
+    });
 }
 
-// ─── CoinGecko OHLC (코인 캔들) ──────────────────────────────
-export async function fetchCoinCandles(coinId, days = 14) {
+// ─── Yahoo Finance 차트 데이터 파싱 ──────────────────────────
+function parseYahooChart(data, isIntraday = false) {
+  const result = data?.chart?.result?.[0];
+  if (!result) throw new Error('No chart data');
+  const timestamps = result.timestamp ?? [];
+  const quotes = result.indicators?.quote?.[0] ?? {};
+  const { open = [], high = [], low = [], close = [] } = quotes;
+  const candles = timestamps.map((ts, i) => ({
+    // 분봉/시봉: Unix seconds (정수), 일봉+: 'YYYY-MM-DD' 문자열
+    time:  isIntraday ? ts : new Date(ts * 1000).toISOString().split('T')[0],
+    open:  open[i], high: high[i], low: low[i], close: close[i],
+  }));
+  return cleanCandles(candles);
+}
+
+// ─── Yahoo Finance v8 차트 (주식 캔들) ───────────────────────
+export async function fetchStockCandles(symbol, range = '1mo', interval = '1d') {
+  const isIntraday = ['5m','15m','30m','60m','90m','1h'].includes(interval);
+
+  // 1순위: Vercel 프록시 (production)
+  try {
+    const res = await fetch(
+      `/api/chart-proxy?symbol=${encodeURIComponent(symbol)}&range=${range}&interval=${interval}`,
+      { signal: AbortSignal.timeout(6000) }
+    );
+    if (res.ok) {
+      const data = await res.json();
+      if (data?.chart?.result?.[0]) {
+        return parseYahooChart(data, isIntraday);
+      }
+    }
+  } catch {}
+
+  // 2순위: allorigins fallback (일봉 이상만)
+  if (!isIntraday) {
+    try {
+      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=${interval}&range=${range}`;
+      const encoded = encodeURIComponent(url);
+      const res = await fetch(`https://api.allorigins.win/get?url=${encoded}`, { signal: AbortSignal.timeout(8000) });
+      if (res.ok) {
+        const json = await res.json();
+        if (json.contents) {
+          const data = JSON.parse(json.contents);
+          if (data?.chart?.result?.[0]) return parseYahooChart(data, false);
+        }
+      }
+    } catch {}
+  }
+
+  throw new Error('차트 데이터 취득 실패');
+}
+
+// ─── Upbit 캔들 API (코인 분봉/일봉/주봉/월봉) ───────────────
+// Upbit REST API는 CORS 허용 + 인증 불필요
+export async function fetchUpbitCandles(symbol, coinType = 'days', coinCount = 200) {
+  const isIntraday = coinType.startsWith('minutes');
+  const market = `KRW-${symbol.toUpperCase()}`;
+  const url = `https://api.upbit.com/v1/candles/${coinType}?market=${encodeURIComponent(market)}&count=${coinCount}`;
+
+  const res = await fetch(url, {
+    headers: { accept: 'application/json' },
+    signal: AbortSignal.timeout(6000),
+  });
+  if (!res.ok) throw new Error(`Upbit ${res.status}`);
+  const raw = await res.json();
+  if (!Array.isArray(raw) || raw.length === 0) throw new Error('Upbit 캔들 없음');
+
+  const candles = raw.map(c => ({
+    // 분봉/시봉: UTC 기준 Unix seconds, 일봉+: 'YYYY-MM-DD'
+    time:   isIntraday
+              ? Math.floor(new Date(c.candle_date_time_utc).getTime() / 1000)
+              : c.candle_date_time_utc.split('T')[0],
+    open:   c.opening_price,
+    high:   c.high_price,
+    low:    c.low_price,
+    close:  c.trade_price,
+    volume: c.candle_acc_trade_volume,
+  }));
+
+  return cleanCandles(candles);
+}
+
+// ─── CoinGecko OHLC fallback (코인 일봉) ──────────────────────
+export async function fetchCoinCandles(coinId, days = 90) {
   const url = `https://api.coingecko.com/api/v3/coins/${coinId}/ohlc?vs_currency=usd&days=${days}`;
   const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
   if (!res.ok) throw new Error(`CoinGecko OHLC ${res.status}`);
@@ -54,55 +131,26 @@ export async function fetchCoinCandles(coinId, days = 14) {
   return cleanCandles(candles);
 }
 
-// ─── Yahoo Finance 차트 데이터 파싱 공통 함수 ────────────────
-function parseYahooChart(data) {
-  const result = data?.chart?.result?.[0];
-  if (!result) throw new Error('No chart data');
-  const timestamps = result.timestamp ?? [];
-  const quotes = result.indicators?.quote?.[0] ?? {};
-  const { open = [], high = [], low = [], close = [] } = quotes;
-  const candles = timestamps.map((ts, i) => ({
-    time:  new Date(ts * 1000).toISOString().split('T')[0],
-    open:  open[i], high: high[i], low: low[i], close: close[i],
-  }));
-  return cleanCandles(candles);
-}
+// ─── 통합 캔들 취득 ──────────────────────────────────────────
+export async function fetchCandles(item, periodKey = '5분') {
+  const config = PERIOD_CONFIG[periodKey] ?? PERIOD_CONFIG['일'];
+  const { interval, range, coinType, coinCount, isIntraday } = config;
 
-// ─── Yahoo Finance v8 차트 (주식 캔들) ───────────────────────
-export async function fetchStockCandles(symbol, range = '1mo') {
-  // 1순위: Vercel 프록시 (production)
-  try {
-    const res = await fetch(`/api/chart-proxy?symbol=${encodeURIComponent(symbol)}&range=${range}`, {
-      signal: AbortSignal.timeout(6000),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      if (data?.chart?.result?.[0]) {
-        return parseYahooChart(data);
-      }
-    }
-  } catch {}
-
-  // 2순위: allorigins fallback
-  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=${range}`;
-  const data = await fetchWithProxy(url);
-  return parseYahooChart(data);
-}
-
-// ─── 기간 → Yahoo range 변환 ─────────────────────────────────
-export const PERIOD_MAP = {
-  '1주': { range: '5d',  coinDays: 1  },
-  '1달': { range: '1mo', coinDays: 14 },
-  '3달': { range: '3mo', coinDays: 30 },
-  '1년': { range: '1y',  coinDays: 90 },
-};
-
-export async function fetchCandles(item, period = '1달') {
-  const { range, coinDays } = PERIOD_MAP[period] ?? PERIOD_MAP['1달'];
   if (item.id) {
-    return fetchCoinCandles(item.id, coinDays);
+    // 코인: Upbit 우선 (분봉/시봉/일봉/주봉/월봉 모두 지원)
+    try {
+      return await fetchUpbitCandles(item.symbol, coinType, coinCount);
+    } catch {
+      // Upbit 실패 시 일봉만 CoinGecko fallback
+      if (!isIntraday) {
+        const coinDays = { '일': 90, '주': 180, '월': 365 }[periodKey] ?? 90;
+        return fetchCoinCandles(item.id, coinDays);
+      }
+      throw new Error('코인 분봉 취득 실패');
+    }
   }
-  // 한국주식: .KS suffix, 미국주식: 그대로
+
+  // 주식: Yahoo Finance (한국 .KS suffix, 미국 그대로)
   const sym = item.market === 'kr' ? `${item.symbol}.KS` : item.symbol;
-  return fetchStockCandles(sym, range);
+  return fetchStockCandles(sym, range, interval);
 }

--- a/src/api/news.js
+++ b/src/api/news.js
@@ -170,6 +170,14 @@ function dedup(items) {
   });
 }
 
+// 7일 이내 뉴스만 허용 (오래된 뉴스 인사이트 제거)
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+function isRecentNews(item) {
+  if (!item.pubDate) return false;
+  try { return Date.now() - new Date(item.pubDate).getTime() < SEVEN_DAYS_MS; }
+  catch { return false; }
+}
+
 // ─────────────────────────────────────────────────────────────
 // 카테고리별 뉴스 취득
 // ─────────────────────────────────────────────────────────────
@@ -201,12 +209,12 @@ async function fetchCoinNews() {
   );
   const allItems = results.flatMap(r => r.status === 'fulfilled' ? r.value : []);
 
-  const items = dedup(allItems.filter(isFinancialNews))
+  const items = dedup(allItems.filter(isFinancialNews).filter(isRecentNews))
     .sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate))
     .slice(0, 30);
 
   if (items.length > 0) cacheSet('coin', items);
-  else if (cached?.data) return cached.data;
+  else if (cached?.data) return cached.data.filter(isRecentNews);
   return items;
 }
 
@@ -250,12 +258,12 @@ async function fetchUsNews() {
   );
   const allItems = results.flatMap(r => r.status === 'fulfilled' ? r.value : []);
 
-  const items = dedup(allItems.filter(isFinancialNews))
+  const items = dedup(allItems.filter(isFinancialNews).filter(isRecentNews))
     .sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate))
     .slice(0, 40);
 
   if (items.length > 0) cacheSet('us', items);
-  else if (cached?.data) return cached.data;
+  else if (cached?.data) return cached.data.filter(isRecentNews);
   return items;
 }
 
@@ -269,12 +277,12 @@ async function fetchKrNews() {
     'kr', '구글뉴스',
   );
 
-  const items = dedup(googleItems.filter(isFinancialNews))
+  const items = dedup(googleItems.filter(isFinancialNews).filter(isRecentNews))
     .sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate))
     .slice(0, 30);
 
   if (items.length > 0) cacheSet('kr', items);
-  else if (cached?.data) return cached.data;
+  else if (cached?.data) return cached.data.filter(isRecentNews);
   return items;
 }
 

--- a/src/api/whale.js
+++ b/src/api/whale.js
@@ -135,8 +135,8 @@ function fmtKrw(n) {
 function connectWs() {
   if (destroyed || !whaleSymbols || !whaleHandler) return;
 
-  const THRESHOLD_KRW = 20_000_000;  // 2000만 원 (BTC 0.2개 수준)
-  const HIGH_KRW      = 100_000_000; // 1억 원
+  const THRESHOLD_KRW = 100_000_000; // 1억 원 (의미 있는 단일 체결 기준)
+  const HIGH_KRW      = 500_000_000; // 5억 원 (기관급 대량 체결)
   const markets = whaleSymbols.map(s => `KRW-${s}`);
 
   try {
@@ -324,12 +324,12 @@ export function startWhaleAlertPolling(callback) {
 function getUpbitInsight(side, tradeAmt) {
   if (side === '매수') {
     if (tradeAmt >= 5e8) return { signal: 'bullish', insight: '기관/세력 대량 매수 — 단기 상방 압력' };
-    if (tradeAmt >= 1e8) return { signal: 'bullish', insight: '대량 매수 체결 — 모멘텀 확인 필요' };
-    return { signal: 'bullish', insight: '고래 단일 체결 감지' };
+    if (tradeAmt >= 2e8) return { signal: 'bullish', insight: '대량 매수 체결 — 모멘텀 확인 필요' };
+    return { signal: 'bullish', insight: '고래 단일 매수 체결 감지 (1억원+)' };
   }
   if (tradeAmt >= 5e8) return { signal: 'bearish', insight: '대규모 차익실현 — 하락 압력 주의' };
-  if (tradeAmt >= 1e8) return { signal: 'bearish', insight: '고래 매도 출현 — 추격매수 주의' };
-  return { signal: 'bearish', insight: '고래 단일 체결 감지' };
+  if (tradeAmt >= 2e8) return { signal: 'bearish', insight: '고래 매도 출현 — 추격매수 주의' };
+  return { signal: 'bearish', insight: '고래 단일 매도 체결 감지 (1억원+)' };
 }
 
 async function pollWhaleAlert(callback) {

--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -21,7 +21,7 @@ class ChartErrorBoundary extends Component {
     return this.props.children;
   }
 }
-import { fetchCandles } from '../api/chart';
+import { fetchCandles, PERIOD_CONFIG } from '../api/chart';
 import { useStockNews } from '../hooks/useNewsQuery';
 import InvestorFlow from './InvestorFlow';
 import { findRelatedItems } from '../data/relatedAssets';
@@ -59,9 +59,13 @@ function PanelLogo({ item }) {
   );
 }
 
-const PERIODS = ['1W', '1M', '3M', '1Y'];
-const PERIOD_LABEL = { '1W': '1주', '1M': '1달', '3M': '3달', '1Y': '1년' };
-const PERIOD_MAP   = { '1W': '1주', '1M': '1달', '3M': '3달', '1Y': '1년' };
+// 타임프레임 버튼 목록 (PERIOD_CONFIG 키와 일치)
+const PERIODS = ['5분', '15분', '30분', '1시간', '4시간', '일', '주', '월'];
+const PERIOD_LABEL = {
+  '5분': '5분', '15분': '15분', '30분': '30분',
+  '1시간': '1H', '4시간': '4H',
+  '일': '일봉', '주': '주봉', '월': '월봉',
+};
 
 function fmt(n, d = 0) {
   if (n == null || isNaN(n)) return '—';
@@ -94,7 +98,7 @@ function timeAgo(date) {
 }
 
 // ─── 차트 컴포넌트 ──────────────────────────────────────────
-function LightweightChart({ candles, loading, type }) {
+function LightweightChart({ candles, loading, type, isIntraday = false }) {
   const containerRef = useRef(null);
   const chartRef     = useRef(null);
 
@@ -115,7 +119,8 @@ function LightweightChart({ candles, loading, type }) {
           grid:   { vertLines: { color: '#F2F4F6' }, horzLines: { color: '#F2F4F6' } },
           crosshair: { mode: CrosshairMode.Normal },
           rightPriceScale: { borderColor: '#E5E8EB' },
-          timeScale: { borderColor: '#E5E8EB', timeVisible: false },
+          // 분봉/시봉: 시간 표시, 일봉+: 날짜만
+          timeScale: { borderColor: '#E5E8EB', timeVisible: isIntraday, secondsVisible: false },
           width,
           height: 300,
         });
@@ -177,7 +182,7 @@ function LightweightChart({ candles, loading, type }) {
 
 // ─── 메인 패널 ──────────────────────────────────────────────
 export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelatedClick, allData = {} }) {
-  const [period,  setPeriod]  = useState('1M');
+  const [period,  setPeriod]  = useState('5분');
   const [candles, setCandles] = useState([]);
   const [chartLoading, setChartLoading] = useState(false);
   const [chartType, setChartType] = useState('candle');
@@ -215,7 +220,7 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
     if (!item) return;
     setChartLoading(true);
     setCandles([]);
-    fetchCandles(item, PERIOD_MAP[period])
+    fetchCandles(item, period)
       .then(data => setCandles(data))
       .catch(() => {
         // 스파크라인 데이터로 fallback
@@ -346,7 +351,12 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
           {/* 차트 — ErrorBoundary로 크래시 격리 */}
           <div className="px-4 pb-2">
             <ChartErrorBoundary>
-              <LightweightChart candles={candles} loading={chartLoading} type={chartType} />
+              <LightweightChart
+                candles={candles}
+                loading={chartLoading}
+                type={chartType}
+                isIntraday={PERIOD_CONFIG[period]?.isIntraday ?? false}
+              />
             </ChartErrorBoundary>
           </div>
 

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -1,0 +1,182 @@
+// 전역 종목 검색 모달 — `/` 키로 열기, ESC / 바깥 클릭으로 닫기
+import { useState, useEffect, useRef, useMemo } from 'react';
+
+function fmt(n, d = 0) {
+  if (n == null || isNaN(n)) return '—';
+  return Number(n).toLocaleString('ko-KR', { minimumFractionDigits: d, maximumFractionDigits: d });
+}
+
+function getPct(item) {
+  return item.id ? (item.change24h ?? 0) : (item.changePct ?? 0);
+}
+
+function getPrice(item, krwRate) {
+  if (item.id) {
+    const p = item.priceKrw || (item.priceUsd ?? 0) * krwRate;
+    if (!p) return '—';
+    if (p < 1)   return `₩${p.toFixed(4)}`;
+    if (p < 100) return `₩${fmt(p, 2)}`;
+    return `₩${fmt(Math.round(p))}`;
+  }
+  if (item.market === 'kr') return `₩${fmt(item.price)}`;
+  if (item.market === 'us') return `₩${fmt(Math.round((item.price ?? 0) * krwRate))}`;
+  return `₩${fmt(item.price)}`;
+}
+
+const MARKET_LABEL = { kr: '국내', us: '미장', coin: '코인', etf: 'ETF' };
+const MARKET_COLOR = { kr: '#F04452', us: '#3182F6', coin: '#FF9500', etf: '#8B5CF6' };
+
+export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [], etfs = [], krwRate = 1466, onSelect, onClose }) {
+  const [query, setQuery] = useState('');
+  const inputRef = useRef(null);
+
+  // 포커스
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // ESC 닫기
+  useEffect(() => {
+    const onKey = e => { if (e.key === 'Escape') onClose?.(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // 전체 종목 합치기 (market 태그 포함)
+  const allItems = useMemo(() => [
+    ...krStocks.map(s => ({ ...s, _market: 'kr' })),
+    ...usStocks.map(s => ({ ...s, _market: 'us' })),
+    ...coins.map(c    => ({ ...c, _market: 'coin' })),
+    ...etfs.map(e     => ({ ...e, _market: 'etf' })),
+  ], [krStocks, usStocks, coins, etfs]);
+
+  const results = useMemo(() => {
+    if (!query.trim()) return [];
+    const q = query.toLowerCase().trim();
+    return allItems
+      .filter(i =>
+        (i.name   || '').toLowerCase().includes(q) ||
+        (i.symbol || '').toLowerCase().includes(q)
+      )
+      .sort((a, b) => {
+        // 심볼 정확 일치 우선
+        const aExact = (a.symbol || '').toLowerCase() === q;
+        const bExact = (b.symbol || '').toLowerCase() === q;
+        if (aExact !== bExact) return aExact ? -1 : 1;
+        // 시작 일치 우선
+        const aStart = (a.name || '').toLowerCase().startsWith(q) || (a.symbol || '').toLowerCase().startsWith(q);
+        const bStart = (b.name || '').toLowerCase().startsWith(q) || (b.symbol || '').toLowerCase().startsWith(q);
+        if (aStart !== bStart) return aStart ? -1 : 1;
+        return 0;
+      })
+      .slice(0, 10);
+  }, [query, allItems]);
+
+  const handleSelect = (item) => {
+    onSelect?.(item);
+    onClose?.();
+  };
+
+  return (
+    <>
+      {/* 배경 딤 */}
+      <div
+        className="fixed inset-0 bg-black/40"
+        style={{ zIndex: 200 }}
+        onClick={onClose}
+      />
+
+      {/* 모달 */}
+      <div
+        className="fixed top-[20vh] left-1/2 -translate-x-1/2 w-full max-w-[560px] bg-white rounded-2xl shadow-2xl overflow-hidden"
+        style={{ zIndex: 201 }}
+      >
+        {/* 검색 입력 */}
+        <div className="flex items-center gap-3 px-4 py-3.5 border-b border-[#F2F4F6]">
+          <svg className="text-[#B0B8C1] flex-shrink-0" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+            <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+          </svg>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="종목명 또는 티커 검색... (예: 삼성전자, BTC, AAPL)"
+            className="flex-1 text-[15px] text-[#191F28] outline-none placeholder:text-[#C9CDD2] bg-transparent"
+          />
+          <kbd
+            onClick={onClose}
+            className="flex-shrink-0 text-[11px] text-[#B0B8C1] bg-[#F2F4F6] px-2 py-0.5 rounded cursor-pointer hover:bg-[#E5E8EB]"
+          >
+            ESC
+          </kbd>
+        </div>
+
+        {/* 결과 */}
+        <div className="max-h-[60vh] overflow-y-auto">
+          {query && results.length === 0 ? (
+            <div className="px-5 py-8 text-center text-[14px] text-[#B0B8C1]">
+              "{query}" 검색 결과가 없습니다.
+            </div>
+          ) : results.length > 0 ? (
+            results.map(item => {
+              const pct = getPct(item);
+              const isUp = pct > 0;
+              const isDown = pct < 0;
+              const market = item._market;
+              return (
+                <button
+                  key={item.id || item.symbol}
+                  onClick={() => handleSelect(item)}
+                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-[#F7F8FA] active:bg-[#F2F4F6] border-b border-[#F2F4F6] last:border-0 transition-colors text-left"
+                >
+                  {/* 마켓 배지 */}
+                  <span
+                    className="text-[10px] font-bold px-1.5 py-0.5 rounded flex-shrink-0"
+                    style={{
+                      background: (MARKET_COLOR[market] ?? '#8B95A1') + '18',
+                      color: MARKET_COLOR[market] ?? '#8B95A1',
+                    }}
+                  >
+                    {MARKET_LABEL[market] ?? market}
+                  </span>
+
+                  {/* 종목 정보 */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[14px] font-semibold text-[#191F28] truncate">{item.name}</span>
+                      <span className="text-[11px] font-bold text-[#8B95A1] font-mono bg-[#F2F4F6] px-1.5 py-0.5 rounded flex-shrink-0">{item.symbol}</span>
+                    </div>
+                    {item.sector && (
+                      <div className="text-[11px] text-[#B0B8C1] mt-0.5">{item.sector}</div>
+                    )}
+                  </div>
+
+                  {/* 가격 + 등락률 */}
+                  <div className="text-right flex-shrink-0">
+                    <div className="text-[13px] font-semibold text-[#191F28] tabular-nums font-mono">
+                      {getPrice(item, krwRate)}
+                    </div>
+                    <div className={`text-[12px] font-bold tabular-nums font-mono ${isUp ? 'text-[#F04452]' : isDown ? 'text-[#1764ED]' : 'text-[#8B95A1]'}`}>
+                      {isUp ? '▲' : isDown ? '▼' : ''}{Math.abs(pct).toFixed(2)}%
+                    </div>
+                  </div>
+                </button>
+              );
+            })
+          ) : (
+            <div className="px-5 py-8 text-center text-[13px] text-[#B0B8C1]">
+              종목명 또는 티커를 입력하세요
+            </div>
+          )}
+        </div>
+
+        {/* 하단 힌트 */}
+        <div className="px-4 py-2.5 bg-[#F8F9FA] border-t border-[#F2F4F6] flex items-center gap-3 text-[11px] text-[#B0B8C1]">
+          <span><kbd className="bg-white border border-[#E5E8EB] px-1 rounded text-[10px]">↑↓</kbd> 이동</span>
+          <span><kbd className="bg-white border border-[#E5E8EB] px-1 rounded text-[10px]">Enter</kbd> 선택</span>
+          <span className="ml-auto">{allItems.length}개 종목 검색 가능</span>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -555,11 +555,16 @@ export default function HomeDashboard({
   // 급등 종목 존재 여부 (3% 이상)
   const hasHotItems = useMemo(() => allItems.some(i => getPct(i) >= 3), [allItems]);
 
-  // 급등 카드용 뉴스 컨텍스트 맵 (symbol → 관련 뉴스 1건)
+  // 급등 카드용 뉴스 컨텍스트 맵 (symbol → 관련 뉴스 1건, 7일 이내만)
   const surgeNewsMap = useMemo(() => {
     if (!allNews.length || !surgeItems.length) return {};
+    const recentNews = allNews.filter(n => {
+      if (!n.pubDate) return false;
+      try { return Date.now() - new Date(n.pubDate).getTime() < 7 * 24 * 60 * 60 * 1000; }
+      catch { return false; }
+    });
     return surgeItems.reduce((acc, item) => {
-      const news = findRelatedNews(item, allNews);
+      const news = findRelatedNews(item, recentNews);
       if (news) acc[item.symbol] = news;
       return acc;
     }, {});
@@ -586,8 +591,14 @@ export default function HomeDashboard({
 
   const insights = useMemo(() => {
     if (!allNews.length || !topMovers.length) return [];
+    // 7일 이내 뉴스만 인사이트로 사용 (오래된 뉴스 신뢰 손상 방지)
+    const recentNews = allNews.filter(n => {
+      if (!n.pubDate) return false;
+      try { return Date.now() - new Date(n.pubDate).getTime() < 7 * 24 * 60 * 60 * 1000; }
+      catch { return false; }
+    });
     return topMovers
-      .map(mover => ({ mover, news: findRelatedNews(mover, allNews) }))
+      .map(mover => ({ mover, news: findRelatedNews(mover, recentNews) }))
       .filter(({ news }) => news !== null)
       .slice(0, 6);
   }, [topMovers, allNews]);

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -197,13 +197,15 @@ const FlashRow = React.memo(function FlashRow({ item, rank, krwRate, onClick, se
         </div>
       </TableCell>
 
-      {/* 현재가 (KRW) — title/subtitle prop 활용 */}
-      <TableCell
-        title={fmtKrwPrice(item, krwRate)}
-        subtitle={usdPrice || undefined}
-        direction="vertical"
-        className="px-3 py-3 text-right"
-      />
+      {/* 현재가 (KRW) */}
+      <TableCell className="px-3 py-3 text-right">
+        <div className="text-[14px] font-semibold text-[#191F28] tabular-nums font-mono">
+          {fmtKrwPrice(item, krwRate)}
+        </div>
+        {usdPrice && (
+          <div className="text-[11px] text-[#8B95A1] tabular-nums font-mono mt-0.5">{usdPrice}</div>
+        )}
+      </TableCell>
 
       {/* 전일대비 */}
       <TableCell className={`px-3 py-3 text-right text-[13px] tabular-nums font-mono ${


### PR DESCRIPTION
## 변경사항

### P0 수정
- **차트 타임프레임**: 5분/15분/30분/1시간/4시간/일/주/월 (5분봉 디폴트)
  - 코인: Upbit REST API 직접 취득 (CORS 허용, 무료)
  - 주식: Yahoo Finance interval 파라미터 추가 (`chart-proxy.js`)
  - 분봉 시 lightweight-charts `timeVisible: true` 적용
- **전역 종목 검색** (`GlobalSearch.jsx`): `/` 키 → 전체 종목 모달 검색
  - 국내/미장/코인/ETF 통합 검색, 정확도 순 정렬
- **뉴스 날짜 필터**: 7일 이내 뉴스만 인사이트·급등카드에 표시
- **고래 알림 임계값**: 2000만원 → 1억원 (5억원 이상 = 기관급)
- **WatchlistTable 현재가 버그**: `title`/`subtitle` HTML 속성 사용으로 가격 셀이 비어있던 문제 수정

## 변경 파일
- `api/chart-proxy.js` — interval 파라미터 추가
- `src/api/chart.js` — 전체 재작성, Upbit candle API 추가
- `src/components/ChartSidePanel.jsx` — 타임프레임 버튼 업데이트, 5분봉 디폴트
- `src/components/GlobalSearch.jsx` — 신규 생성
- `src/App.jsx` — GlobalSearch 연결, `/` 키 리스너
- `src/api/news.js` — 7일 이내 뉴스 필터
- `src/components/HomeDashboard.jsx` — 인사이트 날짜 필터
- `src/api/whale.js` — 임계값 1억원으로 강화
- `src/components/WatchlistTable.jsx` — 현재가 셀 버그 수정