### PR TITLE
fix: 에코프로비엠/오리온 가격 고정 수정 + 전역검색 키보드 네비게이션

### DIFF
--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -136,17 +136,28 @@ const HANTOO_BATCH = 18;
 async function fetchKoreanStocksHantoo(stocks) {
   const symbols = stocks.map(s => s.symbol);
   const results = [];
+  let firstBatchFailed = false;
 
   for (let i = 0; i < symbols.length; i += HANTOO_BATCH) {
     const chunk = symbols.slice(i, i + HANTOO_BATCH);
-    const res = await fetch(
-      `/api/hantoo-price?symbols=${chunk.join(',')}`,
-      { signal: AbortSignal.timeout(10000) }
-    );
-    // 키 미설정(503) 또는 서버 오류(500) → fallback
-    if (!res.ok) throw new Error(`한투 프록시 ${res.status}`);
-    const json = await res.json();
-    if (Array.isArray(json.data)) results.push(...json.data);
+    try {
+      const res = await fetch(
+        `/api/hantoo-price?symbols=${chunk.join(',')}`,
+        { signal: AbortSignal.timeout(10000) }
+      );
+      // 키 미설정(503)은 첫 배치에서만 전체 중단 (불필요한 배치 요청 방지)
+      if (!res.ok) {
+        if (i === 0) throw new Error(`한투 프록시 ${res.status}`);
+        continue; // 중간 배치 실패는 건너뜀
+      }
+      const json = await res.json();
+      if (Array.isArray(json.data)) results.push(...json.data);
+    } catch (e) {
+      if (i === 0) throw e; // 첫 배치 실패 = API 자체 미사용 → fallback
+      // 중간 배치 실패 시 경고 후 계속
+      console.warn(`[한투] 배치 ${i / HANTOO_BATCH + 1} 실패 (건너뜀):`, e.message);
+      continue;
+    }
     // 배치 간 딜레이 (마지막 배치 제외)
     if (i + HANTOO_BATCH < symbols.length) {
       await new Promise(r => setTimeout(r, 50));

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -28,16 +28,43 @@ const MARKET_COLOR = { kr: '#F04452', us: '#3182F6', coin: '#FF9500', etf: '#8B5
 
 export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [], etfs = [], krwRate = 1466, onSelect, onClose }) {
   const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(-1);
   const inputRef = useRef(null);
+  const listRef = useRef(null);
 
   // 포커스
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
-  // ESC 닫기
+  // 쿼리 변경 시 선택 초기화
   useEffect(() => {
-    const onKey = e => { if (e.key === 'Escape') onClose?.(); };
+    setSelectedIndex(-1);
+  }, [query]);
+
+  // ESC + 키보드 네비게이션
+  useEffect(() => {
+    const onKey = e => {
+      if (e.key === 'Escape') { onClose?.(); return; }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const count = listRef.current?.querySelectorAll('button[data-idx]').length ?? 0;
+        setSelectedIndex(i => Math.min(i + 1, count - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex(i => Math.max(i - 1, 0));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        setSelectedIndex(i => {
+          if (i >= 0) {
+            // results는 클로저 밖이므로 DOM에서 클릭 트리거
+            const btns = listRef.current?.querySelectorAll('button[data-idx]');
+            btns?.[i]?.click();
+          }
+          return i;
+        });
+      }
+    };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
@@ -112,23 +139,34 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
         </div>
 
         {/* 결과 */}
-        <div className="max-h-[60vh] overflow-y-auto">
+        <div ref={listRef} className="max-h-[60vh] overflow-y-auto">
           {query && results.length === 0 ? (
             <div className="px-5 py-8 text-center text-[14px] text-[#B0B8C1]">
               "{query}" 검색 결과가 없습니다.
             </div>
           ) : results.length > 0 ? (
-            results.map(item => {
+            results.map((item, idx) => {
               const pct = getPct(item);
               const isUp = pct > 0;
               const isDown = pct < 0;
               const market = item._market;
+              const isSelected = idx === selectedIndex;
               return (
                 <button
                   key={item.id || item.symbol}
+                  data-idx={idx}
                   onClick={() => handleSelect(item)}
-                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-[#F7F8FA] active:bg-[#F2F4F6] border-b border-[#F2F4F6] last:border-0 transition-colors text-left"
+                  onMouseEnter={() => setSelectedIndex(idx)}
+                  className={`w-full flex items-center gap-3 py-3 border-b border-[#F2F4F6] last:border-0 transition-colors text-left relative ${isSelected ? 'bg-[#F2F4F6]' : 'hover:bg-[#F7F8FA] active:bg-[#F2F4F6]'}`}
                 >
+                  {/* 선택 accent bar */}
+                  {isSelected && (
+                    <div className="absolute left-0 top-0 bottom-0 w-[3px] rounded-r" style={{ background: '#3182F6' }} />
+                  )}
+
+                  {/* 왼쪽 패딩 */}
+                  <div className="w-4 flex-shrink-0" />
+
                   {/* 마켓 배지 */}
                   <span
                     className="text-[10px] font-bold px-1.5 py-0.5 rounded flex-shrink-0"
@@ -152,7 +190,7 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
                   </div>
 
                   {/* 가격 + 등락률 */}
-                  <div className="text-right flex-shrink-0">
+                  <div className="text-right flex-shrink-0 pr-4">
                     <div className="text-[13px] font-semibold text-[#191F28] tabular-nums font-mono">
                       {getPrice(item, krwRate)}
                     </div>


### PR DESCRIPTION
## 변경사항

### P0: 에코프로비엠/오리온 가격 고정 버그 수정
- `stocks.js` `fetchKoreanStocksHantoo`: 배치 처리 중 중간 배치 실패 시 `throw`로 이후 전체 배치 중단되던 버그 수정
- 첫 배치 실패 = API 미사용 → fallback, 중간 배치 실패 = `continue`로 건너뜀
- 에코프로비엠(247540), 오리온(271560) 등 후반 배치 종목의 가격이 mock에서 업데이트 안 되던 문제 해결

### P0: GlobalSearch 키보드 네비게이션 구현
- `↑↓` 키 이동, `Enter` 선택, 마우스 호버와 연동
- 선택 항목에 `#3182F6` accent bar + `bg-[#F2F4F6]` 하이라이트
- 쿼리 변경 시 선택 인덱스 자동 초기화