### PR TITLE
fix: ChartSidePanel 모바일 전체화면 + WatchlistTable sortFn 안정화

### DIFF
--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -273,11 +273,11 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
       />
 
       {/* 패널 — full-height, 헤더·배너 위로 슬라이드 */}
+      {/* 모바일: 전체 너비 (48vw = ~180px로 차트 렌더 불가), sm+: min(620px, 48vw) */}
       <div
-        className="fixed top-0 right-0 bg-white shadow-2xl flex flex-col"
+        className="fixed top-0 right-0 bg-white shadow-2xl flex flex-col w-full sm:w-[min(620px,48vw)]"
         style={{
           zIndex: 151,
-          width: 'min(620px, 48vw)',
           height: '100vh',
           borderLeft: '1px solid #E5E8EB',
           animation: 'slideInRight 0.22s cubic-bezier(0.4,0,0.2,1)',
@@ -319,13 +319,14 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
         {/* 스크롤 영역 */}
         <div className="flex-1 overflow-y-auto">
           {/* 기간 + 차트 타입 */}
-          <div className="flex items-center justify-between px-6 py-3">
-            <div className="flex gap-1.5">
+          <div className="flex items-center justify-between px-4 py-3 gap-2">
+            {/* 타임프레임 버튼 — 모바일에서 가로 스크롤 */}
+            <div className="flex gap-1 overflow-x-auto no-scrollbar flex-shrink-1 min-w-0">
               {PERIODS.map(p => (
                 <button
                   key={p}
                   onClick={() => setPeriod(p)}
-                  className={`px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors ${
+                  className={`px-2.5 py-1.5 rounded-lg text-[12px] font-medium transition-colors flex-shrink-0 ${
                     period === p ? 'bg-[#191F28] text-white' : 'bg-[#F2F4F6] text-[#6B7684] hover:bg-[#E5E8EB]'
                   }`}
                 >
@@ -333,7 +334,7 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
                 </button>
               ))}
             </div>
-            <div className="flex gap-1.5">
+            <div className="flex gap-1 flex-shrink-0">
               {['candle', 'line'].map(t => (
                 <button
                   key={t}

--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -4,7 +4,7 @@
 // ③ 3열 HOT 리스트 (국내/미장/코인 각 TOP5)
 // ④ 인사이트 카드 (뉴스 시그널 기반, compact 가로 스크롤)
 
-import { useState, useMemo, memo, useCallback } from 'react';
+import { useState, useMemo, memo } from 'react';
 import MarketSummaryCards from './MarketSummaryCards';
 import Sparkline from './Sparkline';
 import SectorRotation from './SectorRotation';

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -1,5 +1,5 @@
 // 워치리스트 테이블 — 로고 + 섹션 구분 + 티커 심볼 + 클릭 시 차트
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import React from 'react';
 import Sparkline from './Sparkline';
 import { useWatchlist } from '../hooks/useWatchlist';
@@ -314,7 +314,7 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
     else { setSortKey(key); setSortDir('desc'); }
   };
 
-  const sortFn = (list) => [...list].sort((a, b) => {
+  const sortFn = useCallback((list) => [...list].sort((a, b) => {
     let va, vb;
     if (sortKey === 'changePct') {
       va = getPct(a); vb = getPct(b);
@@ -331,7 +331,7 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
       va = a[sortKey] ?? 0; vb = b[sortKey] ?? 0;
     }
     return sortDir === 'desc' ? (vb - va) : (va - vb);
-  });
+  }), [sortKey, sortDir, krwRate]);
 
   const filtered = useMemo(() => {
     let list = [...items];
@@ -363,8 +363,7 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
 
   const flatSorted = useMemo(
     () => sortFn(filtered),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filtered, sortKey, sortDir, krwRate]
+    [filtered, sortFn]
   );
 
   const totalCount = flatSorted.length;


### PR DESCRIPTION
## 변경사항

### P1: ChartSidePanel 모바일 UX
- 패널 너비 `min(620px,48vw)` → 모바일 `w-full` / sm+ `w-[min(620px,48vw)]`
- 375px에서 48vw=180px로 차트 렌더 불가 문제 해결
- 타임프레임 8개 버튼 `overflow-x-auto no-scrollbar` 처리

### P1: WatchlistTable 정렬 안정화
- `sortFn` 인라인 함수 → `useCallback([sortKey,sortDir,krwRate])`
- `flatSorted` eslint-disable-next-line 제거, dep 정리

### 기타
- HomeDashboard `useCallback` dead import 제거