### PR TITLE
fix: watchedItems TDZ 버그 수정 — 블랭크 화면 원인 제거

### DIFF
--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -522,6 +522,12 @@ export default function HomeDashboard({
       .slice(0, 6);
   }, [topMovers, allNews]);
 
+  // ─── 관심종목 필터링 ────────────────────────────────────────
+  const watchedItems = useMemo(
+    () => allItems.filter(i => isWatched(i.id || i.symbol)),
+    [allItems, watchlist] // watchlist dep: Set 변경 시 재계산
+  );
+
   // ─── 관심종목 기반 인사이트 (Job 3 — 포트폴리오 × 뉴스 매칭) ─
   const watchlistInsights = useMemo(() => {
     if (!allNews.length || !watchedItems.length) return [];
@@ -537,12 +543,6 @@ export default function HomeDashboard({
   }, [watchedItems, allNews]);
 
   const hasData = krStocks.length > 0 || usStocks.length > 0 || coins.length > 0;
-
-  // ─── 관심종목 필터링 ────────────────────────────────────────
-  const watchedItems = useMemo(
-    () => allItems.filter(i => isWatched(i.id || i.symbol)),
-    [allItems, watchlist] // watchlist dep: Set 변경 시 재계산
-  );
 
   const today = new Date().toLocaleDateString('ko-KR', {
     year: 'numeric', month: 'long', day: 'numeric', weekday: 'long',


### PR DESCRIPTION
## 변경사항
- `HomeDashboard.jsx`에서 `watchedItems` const 선언 위치를 `watchlistInsights` useMemo **앞으로** 이동
- JavaScript const TDZ(Temporal Dead Zone): `watchlistInsights` deps 배열에서 `watchedItems`를 참조할 때 아직 선언 전이라 `ReferenceError` 발생 → 컴포넌트 렌더 실패 → 블랭크 화면

## 근본 원인
Job 3 구현 시 `watchlistInsights`를 추가하면서 `watchedItems` 선언보다 위에 배치한 것이 원인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)