### PR TITLE
feat: 섹터 로테이션 HOT/COLD MONEY 분리 시각화 (Job 5)

### DIFF
--- a/src/components/SectorRotation.jsx
+++ b/src/components/SectorRotation.jsx
@@ -1,7 +1,33 @@
-// 섹터 로테이션 — 국장 + 미장 섹터별 평균 등락률 막대 시각화
+// 섹터 로테이션 — HOT MONEY / COLD MONEY 분리 시각화 (Job 5)
 import { useState, useMemo } from 'react';
 
 const SECTOR_FLAG = { kr: '🇰🇷', us: '🇺🇸' };
+
+// 섹터 행 공통 컴포넌트
+function SectorRow({ name, avg, market, maxAbs, showFlag }) {
+  const isUp  = avg >= 0;
+  const clr   = avg === 0 ? '#B0B8C1' : isUp ? '#F04452' : '#1764ED';
+  const bgClr = isUp ? 'rgba(240,68,82,0.12)' : 'rgba(23,100,237,0.12)';
+  const pct   = Math.abs(avg) / maxAbs * 100;
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <div className="w-[80px] flex-shrink-0 flex items-center gap-1 min-w-0">
+        {showFlag && <span className="text-[9px] flex-shrink-0">{SECTOR_FLAG[market] ?? ''}</span>}
+        <span className="text-[11px] font-medium text-[#191F28] truncate">{name}</span>
+      </div>
+      <div className="flex-1 h-3.5 rounded-sm overflow-hidden bg-[#F8F9FA]">
+        <div
+          className="h-full rounded-sm transition-all duration-500"
+          style={{ width: `${Math.max(pct, 2)}%`, background: bgClr }}
+        />
+      </div>
+      <span
+        className="text-[11px] font-bold font-mono tabular-nums w-[44px] text-right flex-shrink-0"
+        style={{ color: clr }}
+      >{isUp ? '+' : ''}{avg.toFixed(2)}%</span>
+    </div>
+  );
+}
 
 export default function SectorRotation({ krStocks, usStocks }) {
   const [activeMarket, setActiveMarket] = useState('all');
@@ -28,14 +54,26 @@ export default function SectorRotation({ krStocks, usStocks }) {
   }, [krStocks, usStocks, activeMarket]);
 
   if (!sectorMap.length) return null;
-  const maxAbs = Math.max(...sectorMap.map(s => Math.abs(s.avg)), 0.01);
+
+  // 상승 / 하락 섹터 분리
+  const hotSectors  = sectorMap.filter(s => s.avg > 0);
+  const coldSectors = [...sectorMap.filter(s => s.avg <= 0)].reverse(); // 낙폭 큰 순서
+  const maxAbs      = Math.max(...sectorMap.map(s => Math.abs(s.avg)), 0.01);
+  const showFlag    = activeMarket === 'all';
 
   return (
     <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+      {/* 헤더 */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
         <div className="flex items-center gap-2">
           <span className="text-[14px]">🔄</span>
           <span className="text-[14px] font-bold text-[#191F28]">섹터 로테이션</span>
+          {/* 지금 어디로 돈이 몰리는지 한 줄 요약 */}
+          {hotSectors.length > 0 && (
+            <span className="text-[10px] text-[#8B95A1] font-medium hidden sm:block">
+              자금 유입 {hotSectors.length}개 ↑ · 유출 {coldSectors.length}개 ↓
+            </span>
+          )}
         </div>
         <div className="flex gap-1">
           {[['all', '전체'], ['kr', '🇰🇷'], ['us', '🇺🇸']].map(([id, label]) => (
@@ -49,33 +87,60 @@ export default function SectorRotation({ krStocks, usStocks }) {
           ))}
         </div>
       </div>
-      <div className="p-4 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
-        {sectorMap.map(({ name, avg, market }) => {
-          const isUp  = avg >= 0;
-          const clr   = avg === 0 ? '#B0B8C1' : isUp ? '#F04452' : '#1764ED';
-          const bgClr = isUp ? 'rgba(240,68,82,0.12)' : 'rgba(23,100,237,0.12)';
-          const pct   = Math.abs(avg) / maxAbs * 100;
-          return (
-            <div key={name} className="flex items-center gap-2 min-w-0">
-              <div className="w-[76px] flex-shrink-0 flex items-center gap-1">
-                {activeMarket === 'all' && (
-                  <span className="text-[9px]">{SECTOR_FLAG[market] ?? ''}</span>
-                )}
-                <span className="text-[11px] font-medium text-[#191F28] truncate">{name}</span>
-              </div>
-              <div className="flex-1 h-4 rounded-sm overflow-hidden bg-[#F8F9FA]">
-                <div
-                  className="h-full rounded-sm transition-all duration-300"
-                  style={{ width: `${Math.max(pct, 2)}%`, background: bgClr }}
+
+      {/* HOT MONEY / COLD MONEY 2열 */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-[#F2F4F6]">
+        {/* HOT MONEY — 자금 유입 섹터 */}
+        <div className="p-4">
+          <div className="flex items-center gap-1.5 mb-3">
+            <span className="text-[11px] font-bold text-[#F04452] uppercase tracking-wide">HOT MONEY</span>
+            <span className="text-[10px] text-[#F04452] bg-[#FFF0F1] px-1.5 py-0.5 rounded-full font-semibold">
+              자금 유입
+            </span>
+          </div>
+          {hotSectors.length > 0 ? (
+            <div className="space-y-2">
+              {hotSectors.map(({ name, avg, market }) => (
+                <SectorRow
+                  key={`hot-${name}`}
+                  name={name}
+                  avg={avg}
+                  market={market}
+                  maxAbs={maxAbs}
+                  showFlag={showFlag}
                 />
-              </div>
-              <span
-                className="text-[11px] font-bold font-mono tabular-nums w-[44px] text-right flex-shrink-0"
-                style={{ color: clr }}
-              >{isUp ? '+' : ''}{avg.toFixed(2)}%</span>
+              ))}
             </div>
-          );
-        })}
+          ) : (
+            <div className="py-4 text-center text-[11px] text-[#B0B8C1]">상승 섹터 없음</div>
+          )}
+        </div>
+
+        {/* COLD MONEY — 자금 유출 섹터 */}
+        <div className="p-4">
+          <div className="flex items-center gap-1.5 mb-3">
+            <span className="text-[11px] font-bold text-[#1764ED] uppercase tracking-wide">COLD MONEY</span>
+            <span className="text-[10px] text-[#1764ED] bg-[#EDF4FF] px-1.5 py-0.5 rounded-full font-semibold">
+              자금 유출
+            </span>
+          </div>
+          {coldSectors.length > 0 ? (
+            <div className="space-y-2">
+              {coldSectors.map(({ name, avg, market }) => (
+                <SectorRow
+                  key={`cold-${name}`}
+                  name={name}
+                  avg={avg}
+                  market={market}
+                  maxAbs={maxAbs}
+                  showFlag={showFlag}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="py-4 text-center text-[11px] text-[#B0B8C1]">하락 섹터 없음</div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 변경사항

### SectorRotation.jsx 전면 개선

**이전:** 섹터 전체를 내림차순으로 단순 나열
**이후:** HOT MONEY / COLD MONEY 2열 분리

- **HOT MONEY** (자금 유입): 상승 섹터만 좌측 컬럼, 빨강 계열
- **COLD MONEY** (자금 유출): 하락 섹터만 우측 컬럼, 파랑 계열
- 헤더에 "자금 유입 N개 ↑ · 유출 N개 ↓" 요약 한 줄
- `SectorRow` 컴포넌트 분리 (코드 중복 제거)

### Job 5 달성
"국내/미장/코인 통합으로 섹터 로테이션 파악" — 어디서 돈이 빠지고 어디로 몰리는지 즉시 파악 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)