### PR TITLE
fix: surgeNewsMap TDZ 버그 수정 + US stocks Stooq 1순위

### DIFF
--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -75,13 +75,18 @@ async function fetchYahooChart(symbol) {
 
 // ─── 미국 주식 ─────────────────────────────────────────────────
 export async function fetchUsStocksBatch(symbols) {
-  // 1) Yahoo v7 batch via proxy — 전일 종가 기반 정확한 등락률 제공
+  // 1) Stooq (직접 CORS 허용, 안정적) — Prev_Close 필드 기반 전일 종가 대비 등락률
+  try {
+    const data = await fetchStooq(symbols);
+    if (data.length >= symbols.length * 0.7) return data;
+  } catch {}
+
+  // 2) Yahoo v7 batch via allorigins proxy — Stooq 실패 시 fallback
   try {
     const results = await fetchYahooQuoteBatch(symbols);
     if (results.length >= symbols.length * 0.7) return results.map(r => ({
       symbol:    r.symbol,
       price:     r.regularMarketPrice,
-      // Yahoo: regularMarketChange/Percent 는 전일 종가 대비 → 정확한 등락률
       change:    r.regularMarketChange,
       changePct: r.regularMarketChangePercent,
       volume:    r.regularMarketVolume,
@@ -89,13 +94,6 @@ export async function fetchUsStocksBatch(symbols) {
       high52w:   r.fiftyTwoWeekHigh,
       low52w:    r.fiftyTwoWeekLow,
     }));
-  } catch {}
-
-  // 2) Stooq (Yahoo 실패 시 fallback — 시가 대비 근사치임을 주의)
-  // change/changePct는 당일 시가 대비이므로 정확한 전일 대비 아님
-  try {
-    const data = await fetchStooq(symbols);
-    if (data.length >= symbols.length * 0.7) return data;
   } catch {}
 
   // 3) Yahoo v8 개별 chart — 전일 종가(previousClose) 기반

--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -459,6 +459,17 @@ export default function HomeDashboard({
   const coinItems = useMemo(() => coins.map(c   => ({ ...c, _market: 'COIN' })), [coins]);
   const allItems  = useMemo(() => [...krItems, ...usItems, ...coinItems], [krItems, usItems, coinItems]);
 
+  // ─── 7일 이내 뉴스 (모든 섹션 공통 — surgeNewsMap보다 먼저 선언해야 TDZ 방지) ──
+  const recentNews = useMemo(() => {
+    if (!allNews.length) return [];
+    const cutoff = 7 * 24 * 60 * 60 * 1000;
+    return allNews.filter(n => {
+      if (!n.pubDate) return false;
+      try { return Date.now() - new Date(n.pubDate).getTime() < cutoff; }
+      catch { return false; }
+    });
+  }, [allNews]);
+
   // ─── SECTION 1: 급등 스포트라이트 계산 ─────────────────────
   const surgeItems = useMemo(() => {
     let list = allItems;
@@ -496,17 +507,6 @@ export default function HomeDashboard({
     () => [...coinItems].sort((a, b) => getPct(b) - getPct(a)).slice(0, 5),
     [coinItems]
   );
-
-  // ─── 7일 이내 뉴스 (3개 섹션 공통 사용) ───────────────────
-  const recentNews = useMemo(() => {
-    if (!allNews.length) return [];
-    const cutoff = 7 * 24 * 60 * 60 * 1000;
-    return allNews.filter(n => {
-      if (!n.pubDate) return false;
-      try { return Date.now() - new Date(n.pubDate).getTime() < cutoff; }
-      catch { return false; }
-    });
-  }, [allNews]);
 
   // ─── SECTION 4: 인사이트 (뉴스 × 무버 매칭) ────────────────
   const topMovers = useMemo(() => {


### PR DESCRIPTION
## Summary
- HomeDashboard.jsx: recentNews useMemo가 surgeNewsMap useMemo보다 아래에 선언되어 const TDZ ReferenceError 발생 → 흰화면 버그 수정
- stocks.js: fetchUsStocksBatch 첫 번째 경로를 Stooq(직접 CORS)로 전환 (allorigins 불안정 → 더 안정적인 Stooq 우선)

## Test plan
- [ ] 홈 화면 정상 렌더링 확인
- [ ] 급등 스포트라이트 카드 + 뉴스 컨텍스트 표시 확인
- [ ] 미국 주식 데이터 로딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)