### PR TITLE
fix: 국장 시뮬레이션 제거 + 장 마감 배지

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,6 @@ import GlobalSearch from './components/GlobalSearch';
 import { KOREAN_STOCKS, US_STOCKS_INITIAL, COINS_INITIAL, ETF_DATA, INDICES_INITIAL } from './data/mock';
 import { fetchCoins, fetchCoinsUpbitOnly, fetchExchangeRate } from './api/coins';
 import { fetchUsStocksBatch, fetchKoreanStocksBatch, fetchIndices } from './api/stocks';
-import { getKoreanMarketStatus } from './utils/marketHours';
 import { subscribeCoinPrices, unsubscribeCoinPrices } from './api/coinWs';
 import { requestNotificationPermission, checkAndAlertBatch, getNotificationPermission } from './utils/priceAlert';
 
@@ -25,21 +24,6 @@ const COIN_SYMBOLS = COINS_INITIAL.map(c => c.symbol);
 // ETF 목록은 정적 데이터 — 컴포넌트 외부에서 한 번만 계산
 const ETF_ITEMS    = ETF_DATA.map(e => ({ ...e, marketCap: e.aum }));
 
-// 장 외 시간에도 국장 데이터 소폭 변동 시뮬레이션
-function simulateKorean(stocks) {
-  return stocks.map(s => {
-    const delta    = s.price * (Math.random() - 0.5) * 0.003;
-    const newPrice = Math.round(s.price + delta);
-    const base     = newPrice - s.change;
-    return {
-      ...s,
-      price:     newPrice,
-      change:    Math.round(s.change + delta * 0.7),
-      changePct: base > 0 ? parseFloat(((newPrice - base) / base * 100).toFixed(2)) : s.changePct,
-      sparkline: [...(s.sparkline ?? []).slice(1), newPrice],
-    };
-  });
-}
 
 export default function App() {
   const [activeTab, setActiveTab]         = useState('home');
@@ -171,16 +155,6 @@ export default function App() {
   useEffect(() => { const id = setInterval(refreshCoins, 60000); return () => clearInterval(id); }, [refreshCoins]);
   useEffect(() => { const id = setInterval(refreshUsStocks,    30000); return () => clearInterval(id); }, [refreshUsStocks]);
   useEffect(() => { const id = setInterval(refreshKoreanStocks,30000); return () => clearInterval(id); }, [refreshKoreanStocks]);
-  // 국장 시뮬레이션: 장 외 시간에만 실행 (장 중에는 실제 API 데이터 사용)
-  useEffect(() => {
-    const id = setInterval(() => {
-      const { status } = getKoreanMarketStatus();
-      if (status !== 'open') {
-        setKrStocks(p => simulateKorean(p));
-      }
-    }, 15000);
-    return () => clearInterval(id);
-  }, []);
   useEffect(() => { const id = setInterval(refreshIndices,     60000); return () => clearInterval(id); }, [refreshIndices]);
 
   // 환율 변경 시 ref 동기화 (WS 핸들러에서 클로저 없이 사용)

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -1,6 +1,7 @@
 // 워치리스트 테이블 — 로고 + 섹션 구분 + 티커 심볼 + 클릭 시 차트
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import React from 'react';
+import { getKoreanMarketStatus, getUsMarketStatus } from '../utils/marketHours';
 import Sparkline from './Sparkline';
 import { useWatchlist } from '../hooks/useWatchlist';
 // CDS Table 컴포넌트
@@ -299,6 +300,23 @@ function SortHeader({ label, sortKey, currentKey, currentDir, onSort, className 
 }
 
 
+// 탭 타입별 장 상태 배지 (사용자에게 데이터 freshness 명시)
+function MarketStatusBadge({ type }) {
+  if (type === 'etf' || type === 'coin') return null;
+  const { status, label } = type === 'kr' ? getKoreanMarketStatus() : getUsMarketStatus();
+  if (status === 'open') return null; // 거래 중이면 배지 불필요
+  const text = type === 'kr'
+    ? `${label} · 전일 종가 기준`
+    : status === 'pre' ? `${label} · 정규장 전`
+    : status === 'after' ? `${label} · 정규장 후`
+    : `${label} · 전일 종가 기준`;
+  return (
+    <span className="text-[11px] text-[#8B95A1] bg-[#F2F4F6] px-2 py-1 rounded-lg flex-shrink-0">
+      {text}
+    </span>
+  );
+}
+
 // ─── 메인 컴포넌트 ───────────────────────────────────────────
 export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466, onRowClick, loading = false }) {
   const [sortKey, setSortKey] = useState('changePct');
@@ -436,6 +454,7 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
           ★
         </button>
 
+        <MarketStatusBadge type={type} />
         <span className="ml-auto text-[11px] text-[#B0B8C1] tabular-nums flex-shrink-0">{totalCount}개</span>
       </div>
 


### PR DESCRIPTION
## Summary
- App.jsx: simulateKorean 완전 제거 (장 외 시간 가짜 변동 → 데이터 정합성 문제)
- WatchlistTable.jsx: MarketStatusBadge — 국장/미장 장 상태별 안내 표시

## Test plan
- [ ] 국내 탭 진입 시 "장마감 · 전일 종가 기준" 배지 표시 확인 (장 외 시간)
- [ ] 미장 탭 진입 시 장 상태 배지 표시 확인
- [ ] 거래 중 상태에선 배지 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)