### PR TITLE
feat: 코인 커버리지 확장 (30 → 250+)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,15 +14,14 @@ import HomeDashboard from './components/HomeDashboard';
 import GlobalSearch from './components/GlobalSearch';
 
 import { KOREAN_STOCKS, US_STOCKS_INITIAL, COINS_INITIAL, ETF_DATA, INDICES_INITIAL } from './data/mock';
-import { fetchCoins, fetchCoinsUpbitOnly, fetchExchangeRate } from './api/coins';
+import { fetchCoins, fetchCoinsUpbitOnly, fetchExchangeRate, fetchUpbitAllSymbols } from './api/coins';
 import { fetchUsStocksBatch, fetchKoreanStocksBatch, fetchIndices } from './api/stocks';
 import { subscribeCoinPrices, unsubscribeCoinPrices } from './api/coinWs';
 import { requestNotificationPermission, checkAndAlertBatch, getNotificationPermission } from './utils/priceAlert';
 
-const US_SYMBOLS   = US_STOCKS_INITIAL.map(s => s.symbol);
-const COIN_SYMBOLS = COINS_INITIAL.map(c => c.symbol);
+const US_SYMBOLS = US_STOCKS_INITIAL.map(s => s.symbol);
 // ETF 목록은 정적 데이터 — 컴포넌트 외부에서 한 번만 계산
-const ETF_ITEMS    = ETF_DATA.map(e => ({ ...e, marketCap: e.aum }));
+const ETF_ITEMS  = ETF_DATA.map(e => ({ ...e, marketCap: e.aum }));
 
 
 export default function App() {
@@ -200,11 +199,13 @@ export default function App() {
   }, []);
 
   // ── Upbit WebSocket 코인 가격 실시간 스트림 ─────────────────────
-  // 폴링(10초)과 병행 — WS가 연결되면 <1초 단위 가격 갱신, 끊기면 자동 재연결
+  // 1단계: 초기 30개로 빠르게 구독 시작
+  // 2단계: Upbit 전체 KRW 마켓 목록 로드 후 재구독 (200개+)
   useEffect(() => {
-    subscribeCoinPrices(COIN_SYMBOLS, (tick) => {
-      if (tick._connected) return; // 연결 이벤트 무시
-      // 100ms throttle — 같은 심볼 중복 틱 차단 (WS 폭주 방지)
+    let cancelled = false;
+
+    const wsHandler = (tick) => {
+      if (tick._connected) return;
       const now = Date.now();
       if (now - (wsThrottleRef.current[tick.symbol] ?? 0) < 100) return;
       wsThrottleRef.current[tick.symbol] = now;
@@ -222,8 +223,19 @@ export default function App() {
         };
         return updated;
       });
-    });
-    return () => unsubscribeCoinPrices();
+    };
+
+    // 1단계: COINS_INITIAL 30개로 즉시 구독 (빠른 시작)
+    subscribeCoinPrices(COINS_INITIAL.map(c => c.symbol), wsHandler);
+
+    // 2단계: Upbit 전체 KRW 마켓 (~200개)으로 재구독
+    fetchUpbitAllSymbols()
+      .then(symbols => {
+        if (!cancelled) subscribeCoinPrices(symbols, wsHandler);
+      })
+      .catch(() => {}); // 실패 시 초기 30개 유지
+
+    return () => { cancelled = true; unsubscribeCoinPrices(); };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── 탭별 종목 데이터 (all 탭 제거, home은 HomeDashboard가 담당) ───

--- a/src/api/coins.js
+++ b/src/api/coins.js
@@ -1,72 +1,90 @@
 // 코인 실시간 데이터: Upbit(KRW) + CoinGecko(USD·시총·스파크라인)
+// 코인 커버리지: CoinGecko 시총 상위 250개 + 업비트 상장 전체 (KRW 마켓)
 
-// 업비트에 상장된 코인 마켓 목록 (고정 목록 — WS/REST 폴링 모두 이 목록 사용)
-const UPBIT_MARKETS = [
-  'KRW-BTC','KRW-ETH','KRW-SOL','KRW-XRP','KRW-ADA','KRW-DOGE',
-  'KRW-AVAX','KRW-SHIB','KRW-DOT','KRW-LINK','KRW-UNI','KRW-NEAR',
-  'KRW-APT','KRW-ARB','KRW-SUI','KRW-OP','KRW-PEPE','KRW-XLM',
-  // 추가 코인 (업비트 상장)
-  'KRW-TON','KRW-ATOM','KRW-FIL','KRW-ICP','KRW-HBAR',
-  'KRW-ETC','KRW-SAND','KRW-MANA','KRW-INJ','KRW-SEI',
-  // LTC, BNB 실시간 연결 추가 (업비트 상장)
-  'KRW-LTC','KRW-BNB',
-];
+// ─── Upbit 전체 KRW 마켓 목록 (동적 캐시, 30분 TTL) ──────────
+let upbitMarketCache   = null;
+let upbitMarketCacheAt = 0;
 
-// Upbit 심볼 → CoinGecko ID 매핑
-const UPBIT_TO_CG = {
-  'BTC':'bitcoin','ETH':'ethereum','SOL':'solana','XRP':'ripple',
-  'ADA':'cardano','DOGE':'dogecoin','AVAX':'avalanche-2','SHIB':'shiba-inu',
-  'DOT':'polkadot','LINK':'chainlink','UNI':'uniswap','NEAR':'near',
-  'APT':'aptos','ARB':'arbitrum','SUI':'sui','OP':'optimism',
-  'PEPE':'pepe','XLM':'stellar',
-  // 추가 코인
-  'TON':'the-open-network','ATOM':'cosmos','FIL':'filecoin',
-  'ICP':'internet-computer','HBAR':'hedera-hashgraph','ETC':'ethereum-classic',
-  'SAND':'the-sandbox','MANA':'decentraland','INJ':'injective-protocol','SEI':'sei-network',
-  // 업비트 상장 (LTC, BNB 실시간 연결 추가)
-  'LTC':'litecoin','BNB':'binancecoin',
-};
-
-// CoinGecko ID → Upbit 심볼
-const CG_TO_UPBIT = Object.fromEntries(
-  Object.entries(UPBIT_TO_CG).map(([u, cg]) => [cg, u])
-);
-
-const CG_IDS = Object.values(UPBIT_TO_CG).filter((v, i, a) => a.indexOf(v) === i);
-
-// ─── Upbit 실시간 호가 ─────────────────────────────────────────
-export async function fetchUpbit() {
+export async function fetchUpbitAllSymbols() {
+  const now = Date.now();
+  if (upbitMarketCache && now - upbitMarketCacheAt < 30 * 60 * 1000) {
+    return upbitMarketCache;
+  }
   const res = await fetch(
-    `https://api.upbit.com/v1/ticker?markets=${UPBIT_MARKETS.join(',')}`
+    'https://api.upbit.com/v1/market/all?isDetails=false',
+    { signal: AbortSignal.timeout(5000) }
   );
-  if (!res.ok) throw new Error('Upbit API error');
+  if (!res.ok) throw new Error('Upbit market list error');
   const data = await res.json();
+  const symbols = data
+    .filter(m => m.market.startsWith('KRW-'))
+    .map(m => m.market.replace('KRW-', ''));
+  upbitMarketCache   = symbols;
+  upbitMarketCacheAt = now;
+  return symbols;
+}
 
+// ─── Upbit 실시간 호가 (동적 마켓 목록, 100개씩 청크) ──────────
+// 반환값: { [심볼]: { priceKrw, change24h, ... } }
+export async function fetchUpbit() {
+  const symbols = await fetchUpbitAllSymbols().catch(() => [
+    // Upbit 마켓 조회 실패 시 fallback (자주 거래되는 30개)
+    'BTC','ETH','SOL','XRP','ADA','DOGE','AVAX','SHIB','DOT','LINK',
+    'UNI','NEAR','APT','ARB','SUI','OP','PEPE','XLM','TON','ATOM',
+    'FIL','ICP','HBAR','ETC','SAND','MANA','INJ','SEI','LTC','BNB',
+  ]);
+
+  const markets = symbols.map(s => `KRW-${s}`);
+
+  // Upbit ticker는 한 번에 100개씩 청크 (안정성)
+  const CHUNK = 100;
+  const chunks = [];
+  for (let i = 0; i < markets.length; i += CHUNK) {
+    chunks.push(markets.slice(i, i + CHUNK));
+  }
+
+  const results = await Promise.all(
+    chunks.map(chunk =>
+      fetch(
+        `https://api.upbit.com/v1/ticker?markets=${chunk.join(',')}`,
+        { signal: AbortSignal.timeout(8000) }
+      )
+        .then(r => (r.ok ? r.json() : []))
+        .catch(() => [])
+    )
+  );
+  const data = results.flat();
+
+  // 심볼(대문자) 기준으로 인덱싱
   const map = {};
   for (const d of data) {
-    const sym  = d.market.replace('KRW-', '');
-    const cgId = UPBIT_TO_CG[sym];
-    if (cgId) {
-      map[cgId] = {
-        priceKrw:  d.trade_price,
-        change24h: d.signed_change_rate * 100,
-        volume24hKrw: d.acc_trade_price_24h,
-        high24hKrw:   d.high_price,
-        low24hKrw:    d.low_price,
-        high52wKrw:   d.highest_52_week_price,
-        low52wKrw:    d.lowest_52_week_price,
-      };
-    }
+    const sym = d.market.replace('KRW-', '');
+    map[sym] = {
+      priceKrw:     d.trade_price,
+      change24h:    d.signed_change_rate * 100,
+      volume24hKrw: d.acc_trade_price_24h,
+      high24hKrw:   d.high_price,
+      low24hKrw:    d.low_price,
+      high52wKrw:   d.highest_52_week_price,
+      low52wKrw:    d.lowest_52_week_price,
+    };
   }
   return map;
 }
 
-// ─── CoinGecko (USD + 시총 + 스파크라인) — 60초 간격 권장 ────
+// ─── CoinGecko 시총 상위 250개 (USD·시총·스파크라인) ────────────
+// 60초 간격 권장 (공개 API ~30req/min)
 export async function fetchCoinGecko() {
-  const ids = CG_IDS.join(',');
-  // x_cg_demo_api_key 없이도 동작하는 공개 엔드포인트 (rate: ~30req/min)
-  const url = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${ids}&order=market_cap_desc&per_page=50&page=1&sparkline=true&price_change_percentage=24h`;
-  const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
+  const url = [
+    'https://api.coingecko.com/api/v3/coins/markets',
+    '?vs_currency=usd',
+    '&order=market_cap_desc',
+    '&per_page=250',
+    '&page=1',
+    '&sparkline=true',
+    '&price_change_percentage=24h',
+  ].join('');
+  const res = await fetch(url, { signal: AbortSignal.timeout(15000) });
   if (!res.ok) throw new Error(`CoinGecko ${res.status}`);
   return res.json();
 }
@@ -74,24 +92,22 @@ export async function fetchCoinGecko() {
 // CoinGecko 캐시 — 마지막 성공한 데이터 보존
 let cgCache = [];
 
-// ─── 환율: Binance(1순위) → Upbit+CoinGecko(2순위) → localStorage 캐시(3순위) → 하드코딩(최후) ─
+// ─── 환율: Binance(1순위) → Upbit+CoinGecko(2순위) → localStorage(3순위) → 하드코딩 ─
 const RATE_CACHE_KEY = 'market_krw_rate';
 const RATE_FALLBACK  = 1466;
 
-// 환율을 localStorage에 저장 (성공 시 호출)
 function saveRateCache(rate) {
   try {
     localStorage.setItem(RATE_CACHE_KEY, JSON.stringify({ rate, ts: Date.now() }));
   } catch {}
 }
 
-// localStorage에서 24시간 내 캐시된 환율 읽기
 function loadRateCache() {
   try {
     const cached = localStorage.getItem(RATE_CACHE_KEY);
     if (!cached) return null;
     const { rate, ts } = JSON.parse(cached);
-    if (Date.now() - ts < 24 * 60 * 60 * 1000) return rate; // 24시간 이내
+    if (Date.now() - ts < 24 * 60 * 60 * 1000) return rate;
   } catch {}
   return null;
 }
@@ -108,12 +124,12 @@ export async function fetchExchangeRate() {
     const btcUsd = parseFloat(binanceData?.price);
     if (btcKrw && btcUsd) {
       const rate = Math.round(btcKrw / btcUsd);
-      saveRateCache(rate); // 성공 시 localStorage에 저장
+      saveRateCache(rate);
       return rate;
     }
   } catch {}
 
-  // 2순위: Upbit + CoinGecko (기존 방식)
+  // 2순위: Upbit + CoinGecko
   try {
     const res = await fetch('https://api.upbit.com/v1/ticker?markets=KRW-BTC', { signal: AbortSignal.timeout(4000) });
     const data = await res.json();
@@ -123,16 +139,15 @@ export async function fetchExchangeRate() {
     const btcUsd = cgData?.bitcoin?.usd;
     if (btcKrw && btcUsd) {
       const rate = Math.round(btcKrw / btcUsd);
-      saveRateCache(rate); // 성공 시 localStorage에 저장
+      saveRateCache(rate);
       return rate;
     }
   } catch {}
 
-  // 3순위: localStorage 캐시 (24시간 이내 저장값) — 실제 환율과 크게 차이 안 남
+  // 3순위: localStorage 캐시 (24시간 이내)
   const cachedRate = loadRateCache();
   if (cachedRate) return cachedRate;
 
-  // 최후 fallback: 하드코딩 기본값
   return RATE_FALLBACK;
 }
 
@@ -142,33 +157,35 @@ export async function fetchCoinsUpbitOnly(prevCoins = [], krwRate = 1466) {
   if (!Object.keys(upbitMap).length) return prevCoins;
 
   return prevCoins.map(coin => {
-    const upbit = upbitMap[coin.id];
-    if (!upbit) return coin; // Upbit 미상장 코인은 기존 데이터(coingecko) 유지
+    const upbit = upbitMap[coin.symbol]; // 심볼 기준 매칭
+    if (!upbit) return coin; // Upbit 미상장 → CoinGecko 데이터 유지
     return {
       ...coin,
       priceKrw:    upbit.priceKrw,
       priceUsd:    upbit.priceKrw / krwRate,
       change24h:   upbit.change24h,
       volume24h:   upbit.volume24hKrw / krwRate,
-      priceSource: 'upbit', // 10초 폴링은 항상 Upbit 소스
+      priceSource: 'upbit',
     };
   });
 }
 
-// ─── 통합 코인 데이터 (CoinGecko 포함 — 60초 폴링용) ──────────
+// ─── 통합 코인 데이터 (CoinGecko top 250 + Upbit KRW 가격 병합) ──
+// CoinGecko 결과를 기준으로, Upbit에 상장된 코인은 KRW 실시간 가격으로 덮어씀
 export async function fetchCoins(krwRate = 1466) {
   const [upbitMap, cgListRaw] = await Promise.all([
     fetchUpbit().catch(() => ({})),
     fetchCoinGecko().catch(() => null),
   ]);
 
-  // CoinGecko 실패 시 캐시 사용
   const cgList = cgListRaw ?? cgCache;
   if (!cgList.length) throw new Error('CoinGecko 실패 (캐시 없음)');
-  if (cgListRaw) cgCache = cgListRaw; // 성공하면 캐시 갱신
+  if (cgListRaw) cgCache = cgListRaw;
 
   return cgList.map(coin => {
-    const upbit = upbitMap[coin.id] ?? {};
+    // CoinGecko 심볼 → 대문자로 Upbit 매핑 (UPBIT_TO_CG 하드코딩 불필요)
+    const sym    = coin.symbol.toUpperCase();
+    const upbit  = upbitMap[sym] ?? {};
     const priceKrw = upbit.priceKrw ?? coin.current_price * krwRate;
     const priceUsd = coin.current_price;
     const change24h = upbit.change24h ?? coin.price_change_percentage_24h ?? 0;
@@ -176,28 +193,24 @@ export async function fetchCoins(krwRate = 1466) {
     const sparkline = sparkRaw.length > 20
       ? sparkRaw.filter((_, i) => i % Math.ceil(sparkRaw.length / 20) === 0).slice(0, 20)
       : sparkRaw;
-
-    // 가격 소스: Upbit 우선, 없으면 CoinGecko fallback
     const hasUpbit = !!upbit.priceKrw;
 
     return {
       id:       coin.id,
-      symbol:   coin.symbol.toUpperCase(),
+      symbol:   sym,
       name:     coin.name,
       priceUsd,
       priceKrw,
       change24h,
       volume24h: (upbit.volume24hKrw ?? 0) / krwRate || coin.total_volume,
-      // CoinGecko 전용: 시총·도미넌스 계산에 사용
       marketCap: coin.market_cap,
       high24h: upbit.high24hKrw ? upbit.high24hKrw / krwRate : coin.high_24h,
       low24h:  upbit.low24hKrw  ? upbit.low24hKrw  / krwRate : coin.low_24h,
       high52w: upbit.high52wKrw ? upbit.high52wKrw / krwRate : null,
       low52w:  upbit.low52wKrw  ? upbit.low52wKrw  / krwRate : null,
-      // CoinGecko 전용: 스파크라인 7일치
       sparkline,
       image: coin.image,
-      // 가격 기준 명시: 프론트에서 출처 배지 표시 가능
+      // 가격 출처: 프론트 배지 표시용
       priceSource: hasUpbit ? 'upbit' : 'coingecko',
     };
   });


### PR DESCRIPTION
## 변경 요약
- CoinGecko top 250 조회 (기존 30개 고정 목록 제거)
- Upbit 전체 KRW 마켓 동적 조회 (`/v1/market/all`) — 하드코딩 UPBIT_MARKETS 제거
- 심볼 매칭: UPBIT_TO_CG 하드코딩 맵 → `coin.symbol.toUpperCase()` 자동 매칭
- WS 구독: 초기 30개 즉시 구독 → Upbit 전체 마켓 로드 후 재구독 (~200개)
- Upbit ticker 100개씩 청크 처리 (안정성)

## 효과
- 코인 탭: 30개 → 250개 (CoinGecko 기준)
- Upbit 상장 코인 실시간 WS 가격: ~30개 → ~200개
- USDT, STABLECOINS 등 CoinGecko 상위권이지만 기존 누락된 코인 포함