### PR TITLE
feat: 스테이블코인 제거 + 코인 탭 페이지네이션

### DIFF
--- a/src/api/coins.js
+++ b/src/api/coins.js
@@ -1,5 +1,15 @@
 // 코인 실시간 데이터: Upbit(KRW) + CoinGecko(USD·시총·스파크라인)
 // 코인 커버리지: CoinGecko 시총 상위 250개 + 업비트 상장 전체 (KRW 마켓)
+// 스테이블코인·wrapped 토큰은 급등 캐치 목적과 무관 → fetchCoins()에서 제거
+
+// 필터링 대상: 가격 변동이 없거나 원본 자산의 래핑본인 토큰
+const EXCLUDED_SYMBOLS = new Set([
+  // 스테이블코인 (USD 고정)
+  'USDT','USDC','DAI','BUSD','TUSD','PYUSD','USDS','USDE','FDUSD','FRAX',
+  'LUSD','USDP','GUSD','SUSD','ALUSD','CRVUSD','GHO','CUSD','EURI','USDD',
+  // wrapped / staked 토큰 (원본과 거의 동일)
+  'WBTC','WETH','STETH','WSTETH','CBETH','RETH','WEETH','EZETH','RSETH',
+]);
 
 // ─── Upbit 전체 KRW 마켓 목록 (동적 캐시, 30분 TTL) ──────────
 let upbitMarketCache   = null;
@@ -182,7 +192,9 @@ export async function fetchCoins(krwRate = 1466) {
   if (!cgList.length) throw new Error('CoinGecko 실패 (캐시 없음)');
   if (cgListRaw) cgCache = cgListRaw;
 
-  return cgList.map(coin => {
+  return cgList
+    .filter(coin => !EXCLUDED_SYMBOLS.has(coin.symbol.toUpperCase()))
+    .map(coin => {
     // CoinGecko 심볼 → 대문자로 Upbit 매핑 (UPBIT_TO_CG 하드코딩 불필요)
     const sym    = coin.symbol.toUpperCase();
     const upbit  = upbitMap[sym] ?? {};

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -325,6 +325,9 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
   const [filter,  setFilter]  = useState('all');
   const [sector,  setSector]  = useState(null);
   const [showWatchlistOnly, setShowWatchlistOnly] = useState(false);
+  // 코인 탭: 100개씩 표시 (250개 한번에 렌더링 성능 방지)
+  const PAGE_SIZE   = 100;
+  const [pageLimit, setPageLimit] = useState(PAGE_SIZE);
   const { toggle, isWatched, watchlist } = useWatchlist();
 
   const handleSort = (key) => {
@@ -385,13 +388,16 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
   );
 
   const totalCount = flatSorted.length;
+  // 코인 탭은 pageLimit만큼만 렌더링, 나머지는 "더 보기"로
+  const displayedRows = type === 'coin' ? flatSorted.slice(0, pageLimit) : flatSorted;
+  const hasMore       = type === 'coin' && flatSorted.length > pageLimit;
 
   const renderRows = () => {
     // 초기 로딩: 데이터 없고 loading 중일 때 스켈레톤 표시
     if (loading && items.length === 0) {
       return Array.from({ length: 8 }).map((_, i) => <SkeletonRow key={i} />);
     }
-    return flatSorted.map((item, i) => (
+    return displayedRows.map((item, i) => (
       <FlashRow
         key={item.id || item.symbol}
         item={item}
@@ -526,6 +532,18 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
         {totalCount === 0 && (
           <div className="py-16 text-center text-[14px] text-[#B0B8C1]">
             {search ? `"${search}" 검색 결과가 없습니다.` : '데이터 없음'}
+          </div>
+        )}
+
+        {/* 코인 탭 더 보기 버튼 */}
+        {hasMore && (
+          <div className="py-4 text-center border-t border-[#F2F4F6]">
+            <button
+              onClick={() => setPageLimit(l => l + PAGE_SIZE)}
+              className="px-5 py-2 text-[13px] font-medium text-[#3182F6] bg-[#F0F5FF] hover:bg-[#DCE8FF] rounded-lg transition-colors"
+            >
+              더 보기 ({flatSorted.length - pageLimit}개 남음)
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## 변경 요약
- **스테이블코인·wrapped 토큰 제거** (coins.js fetchCoins 필터링)
  - USDT, USDC, DAI, BUSD, TUSD, PYUSD, FRAX 등 USD 고정 코인 제거
  - WBTC, WETH, STETH, WSTETH 등 wrapped 토큰 제거
  - 약 250개 → ~230개 (급등 캐치 무의미한 코인 제거)
- **코인 탭 100개씩 페이지네이션** (WatchlistTable)
  - 250개 FlashRow 동시 렌더링 방지 (각 행마다 useEffect+useRef+Sparkline)
  - 첫 로드: 100개 표시, "더 보기" 버튼으로 100개씩 추가
  - 검색/필터 적용 시 전체 결과에서 페이지네이션