### PR TITLE
ux/perf: 코인탭 초기 로딩 스켈레톤 + 배너 급등 상한

### DIFF
--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -29,8 +29,8 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick
 
     const hot = all.filter(i => i.pct >= 3);
     const hasHot = hot.length > 0;
-    // 급등 있으면 급등만, 없으면 상위 5개
-    const base = hasHot ? hot : all.slice(0, 5);
+    // 급등 있으면 급등만 최대 20개, 없으면 상위 5개 (250개 코인 확장 후 너무 많아지는 방지)
+    const base = hasHot ? hot.slice(0, 20) : all.slice(0, 5);
     // 무한 스크롤 효과를 위해 2배 복제
     return { items: [...base, ...base], hasHot };
   }, [stocks, coins]);

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -406,8 +406,9 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
   const hasMore       = type === 'coin' && flatSorted.length > pageLimit;
 
   const renderRows = () => {
-    // 초기 로딩: 데이터 없고 loading 중일 때 스켈레톤 표시
-    if (loading && items.length === 0) {
+    // 초기 로딩: 데이터 없거나, 코인 탭에서 30개 이하(COINS_INITIAL mock) + 로딩 중이면 스켈레톤
+    const isInitialCoinLoad = type === 'coin' && loading && items.length <= 30;
+    if ((loading && items.length === 0) || isInitialCoinLoad) {
       return Array.from({ length: 8 }).map((_, i) => <SkeletonRow key={i} />);
     }
     return displayedRows.map((item, i) => (


### PR DESCRIPTION
## 변경 요약
- **코인 탭 로딩 스켈레톤**: COINS_INITIAL 30개(mock) 상태에서 로딩 중일 때 스켈레톤 표시 (30→230 갑작스런 카운트 점프 방지)
- **SurgeBanner 급등 상한**: 코인 250개 확장 후 급등(>=3%) 코인이 50개+ 될 수 있어 최대 20개로 제한