### PR TITLE
fix: 고래 알림 KRW 환율 하드코딩 제거 + WhalePanel 동적 심볼

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import { fetchCoins, fetchCoinsUpbitOnly, fetchExchangeRate, fetchUpbitAllSymbol
 import { fetchUsStocksBatch, fetchKoreanStocksBatch, fetchIndices } from './api/stocks';
 import { subscribeCoinPrices, unsubscribeCoinPrices } from './api/coinWs';
 import { requestNotificationPermission, checkAndAlertBatch, getNotificationPermission } from './utils/priceAlert';
+import { setWhaleKrwRate, setWhaleBtcKrwPrice } from './api/whale';
 
 const US_SYMBOLS = US_STOCKS_INITIAL.map(s => s.symbol);
 // ETF 목록은 정적 데이터 — 컴포넌트 외부에서 한 번만 계산
@@ -157,8 +158,17 @@ export default function App() {
   useEffect(() => { const id = setInterval(refreshKoreanStocks,30000); return () => clearInterval(id); }, [refreshKoreanStocks]);
   useEffect(() => { const id = setInterval(refreshIndices,     60000); return () => clearInterval(id); }, [refreshIndices]);
 
-  // 환율 변경 시 ref 동기화 (WS 핸들러에서 클로저 없이 사용)
-  useEffect(() => { krwRateRef.current = krwRate; }, [krwRate]);
+  // 환율 변경 시 ref 동기화 + whale 모듈 환율 주입
+  useEffect(() => {
+    krwRateRef.current = krwRate;
+    setWhaleKrwRate(krwRate);
+  }, [krwRate]);
+
+  // 코인 업데이트 시 whale 모듈에 BTC KRW 가격 주입
+  useEffect(() => {
+    const btc = coins.find(c => c.symbol === 'BTC');
+    if (btc?.priceKrw) setWhaleBtcKrwPrice(btc.priceKrw);
+  }, [coins]);
 
   // ── 브라우저 알림 권한 요청 (초기 1회) ──────────────────────────
   useEffect(() => { requestNotificationPermission(); }, []);

--- a/src/api/whale.js
+++ b/src/api/whale.js
@@ -21,6 +21,20 @@
 //   - 실제 온체인 고래 TX 추적은 불가
 //   - 가격/거래량 이상 징후 감지로 대체 (간접 지표)
 
+// ─── 환율 / BTC 가격 (App.jsx에서 주입) ──────────────────────
+let currentKrwRate    = 1466;       // USD → KRW 환율
+let currentBtcKrwPrice = 130_000_000; // BTC 현재가 (원)
+
+/** USD/KRW 환율 업데이트 — App.jsx에서 fetchExchangeRate() 결과로 호출 */
+export function setWhaleKrwRate(rate) {
+  if (rate > 0) currentKrwRate = rate;
+}
+
+/** BTC KRW 가격 업데이트 — App.jsx에서 coins 갱신 시 호출 */
+export function setWhaleBtcKrwPrice(price) {
+  if (price > 0) currentBtcKrwPrice = price;
+}
+
 // ─── 스냅샷 저장소 ────────────────────────────────────────────
 // { coinId: { priceKrw, volume24h, timestamp } }
 let prevSnapshot = {};
@@ -269,8 +283,8 @@ function connectBtcWs(callback) {
         // outputs 합산 (satoshi → BTC)
         const totalBtc = (tx.out || []).reduce((s, o) => s + (o.value || 0), 0) / 1e8;
         if (totalBtc < BTC_WHALE_THRESHOLD) return;
-        // 전역 BTC 가격 활용 (WhalePanel에서 window.__btcKrwRate__ 설정)
-        const amtKrw = totalBtc * (window.__btcKrwRate__ || 100_000_000);
+        // 모듈 레벨 BTC KRW 가격 사용 (setWhaleBtcKrwPrice로 주입)
+        const amtKrw = totalBtc * currentBtcKrwPrice;
         callback({
           id:        tx.hash?.slice(0, 8) + '-btc',
           symbol:    'BTC',
@@ -382,7 +396,7 @@ async function pollWhaleAlert(callback) {
         symbol:       tx.symbol?.toUpperCase() || '?',
         chain:        tx.blockchain,
         side:         '온체인',
-        tradeAmt:     Math.round((tx.amount_usd || 0) * 1300), // USD→KRW 근사
+        tradeAmt:     Math.round((tx.amount_usd || 0) * currentKrwRate), // USD→KRW (환율 동적 반영)
         volume:       tx.amount,
         severity:     tx.amount_usd >= 10_000_000 ? 'high' : 'normal',
         timestamp:    (tx.timestamp || 0) * 1000,

--- a/src/components/WhalePanel.jsx
+++ b/src/components/WhalePanel.jsx
@@ -2,7 +2,7 @@
 // 소스 1: Upbit WebSocket (2000만원+ 단일 체결)
 // 소스 2: Blockchain.com WebSocket (10 BTC+ 온체인 이동)
 // 소스 3: Whale Alert REST 폴링 (Vercel 프록시, 60초 간격)
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   subscribeUpbitWhaleTrades,
   unsubscribeUpbitWhaleTrades,
@@ -11,6 +11,7 @@ import {
   startWhaleAlertPolling,
   stopWhaleAlertPolling,
 } from '../api/whale';
+import { fetchUpbitAllSymbols } from '../api/coins';
 import { pushWhaleEvent } from '../state/whaleBus';
 
 const MAX_EVENTS = 30;
@@ -320,8 +321,8 @@ function EventRow({ event, onItemClick, coinMap }) {
   );
 }
 
-// Upbit KRW 마켓 감시 종목 목록
-const WATCH_SYMBOLS = [
+// 폴백: Upbit KRW 마켓 기본 20개 (동적 로딩 전 사용)
+const FALLBACK_SYMBOLS = [
   'BTC','ETH','XRP','SOL','ADA','DOGE','AVAX','DOT','LINK','UNI',
   'NEAR','APT','ARB','SUI','OP','PEPE','XLM','TON','ATOM','INJ',
 ];
@@ -331,12 +332,20 @@ export default function WhalePanel({ isVisible = true, coins = [], onItemClick }
   const [connected,    setConnected]    = useState(false);
   const [btcConnected, setBtcConnected] = useState(false);
   const [msgCount,     setMsgCount]     = useState(0); // WS 수신 전체 체결 수
+  const [watchSymbols, setWatchSymbols] = useState(FALLBACK_SYMBOLS); // 동적 Upbit 심볼
 
-  // 심볼 → 코인 빠른 조회 맵
-  const coinMap = coins.reduce((m, c) => {
+  // 심볼 → 코인 빠른 조회 맵 (coins 변경 시에만 재계산)
+  const coinMap = useMemo(() => coins.reduce((m, c) => {
     if (c.symbol) m[c.symbol.toUpperCase()] = c;
     return m;
-  }, {});
+  }, {}), [coins]);
+
+  // Upbit 전체 KRW 마켓 심볼 동적 로딩 (1회)
+  useEffect(() => {
+    fetchUpbitAllSymbols()
+      .then(symbols => { if (symbols.length > 0) setWatchSymbols(symbols); })
+      .catch(() => {}); // 실패 시 폴백 유지
+  }, []);
 
   // 이벤트 추가 헬퍼 (MAX_EVENTS 제한 + 버스 발행)
   const addEvent = (evt) => {
@@ -351,8 +360,8 @@ export default function WhalePanel({ isVisible = true, coins = [], onItemClick }
     setBtcConnected(false);
     setMsgCount(0);
 
-    // ── 소스 1: Upbit WebSocket ─────────────────────────────────
-    subscribeUpbitWhaleTrades(WATCH_SYMBOLS, (evt) => {
+    // ── 소스 1: Upbit WebSocket (전체 KRW 마켓 감시) ─────────────
+    subscribeUpbitWhaleTrades(watchSymbols, (evt) => {
       if (evt._connected) { setConnected(true); return; }
       if (evt._tick)      { setConnected(true); setMsgCount(p => p + 1); return; }
       setConnected(true);
@@ -379,7 +388,7 @@ export default function WhalePanel({ isVisible = true, coins = [], onItemClick }
       setConnected(false);
       setBtcConnected(false);
     };
-  }, [isVisible]);
+  }, [isVisible, watchSymbols]);
 
   // 연결 상태 텍스트
   const connStatus = connected && btcConnected


### PR DESCRIPTION
## 변경사항

### 데이터 정합성 버그 수정
- `whale.js` 환율 1300 하드코딩 → 실제 환율 동적 적용 (~1466, 11% 오차 수정)
- `whale.js` `window.__btcKrwRate__` 미설정 버그 수정 — BTC 온체인 금액이 100M KRW 기본값 사용하던 문제 해결
- `setWhaleKrwRate()`, `setWhaleBtcKrwPrice()` 모듈 export 추가
- `App.jsx` — krwRate 변경 시 whale 모듈에 환율 주입, coins 업데이트 시 BTC KRW 가격 주입

### 성능 + 커버리지 개선
- `WhalePanel` WATCH_SYMBOLS 20개 하드코딩 → `fetchUpbitAllSymbols()` 동적 로딩 (~200개)
- `coinMap` useMemo 추가 — 매 렌더마다 reduce 재실행 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)