### PR TITLE
feat: 급락 노출 + 연관종목/뉴스 시스템 개선

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,8 +22,6 @@ import { setWhaleKrwRate, setWhaleBtcKrwPrice } from './api/whale';
 import { useWatchlist } from './hooks/useWatchlist';
 
 const US_SYMBOLS = US_STOCKS_INITIAL.map(s => s.symbol);
-// ETF 목록은 정적 데이터 — 컴포넌트 외부에서 한 번만 계산
-const ETF_ITEMS  = ETF_DATA.map(e => ({ ...e, marketCap: e.aum }));
 
 
 export default function App() {
@@ -32,8 +30,7 @@ export default function App() {
   const [coins, setCoins]                 = useState(COINS_INITIAL);
   const [usStocks, setUsStocks]           = useState(US_STOCKS_INITIAL);
   const [krStocks, setKrStocks]           = useState(KOREAN_STOCKS);
-  // etfs는 정적 데이터 — state 불필요 (모듈 레벨 ETF_ITEMS 사용)
-  const etfs = ETF_DATA;
+  const [etfs, setEtfs]                   = useState(ETF_DATA);
   const [indices, setIndices]             = useState(INDICES_INITIAL);
   const [krwRate, setKrwRate]             = useState(1466);
   const [lastUpdated, setLastUpdated]     = useState(null);
@@ -104,6 +101,22 @@ export default function App() {
     } catch (e) { console.warn('미장 갱신 실패:', e.message); }
   }, []);
 
+  // ── ETF 실시간 갱신 (60초) ──────────────────────────────────
+  const ETF_SYMBOLS = useMemo(() => ETF_DATA.map(e => e.symbol), []);
+
+  const refreshEtfs = useCallback(async () => {
+    try {
+      const fresh = await fetchUsStocksBatch(ETF_SYMBOLS);
+      if (fresh.length > 0) {
+        setEtfs(prev => prev.map(etf => {
+          const f = fresh.find(s => s.symbol === etf.symbol);
+          if (!f) return etf;
+          return { ...etf, price: f.price, change: f.change, changePct: f.changePct };
+        }));
+      }
+    } catch {}
+  }, [ETF_SYMBOLS]);
+
   // ── 국장 갱신 (30초) ────────────────────────────────────────
   const refreshKoreanStocks = useCallback(async () => {
     try {
@@ -159,6 +172,12 @@ export default function App() {
   useEffect(() => { const id = setInterval(refreshUsStocks,    30000); return () => clearInterval(id); }, [refreshUsStocks]);
   useEffect(() => { const id = setInterval(refreshKoreanStocks,30000); return () => clearInterval(id); }, [refreshKoreanStocks]);
   useEffect(() => { const id = setInterval(refreshIndices,     60000); return () => clearInterval(id); }, [refreshIndices]);
+  // ETF 가격 갱신: 마운트 즉시 + 60초마다
+  useEffect(() => {
+    refreshEtfs();
+    const id = setInterval(refreshEtfs, 60000);
+    return () => clearInterval(id);
+  }, [refreshEtfs]);
 
   // 환율 변경 시 ref 동기화 + whale 모듈 환율 주입
   useEffect(() => {
@@ -276,8 +295,10 @@ export default function App() {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ── ETF 아이템 (etfs state 기반) ────────────────────────────
+  const etfItems = useMemo(() => etfs.map(e => ({ ...e, marketCap: e.aum })), [etfs]);
+
   // ── 탭별 종목 데이터 (all 탭 제거, home은 HomeDashboard가 담당) ───
-  // ETF_ITEMS는 모듈 레벨 상수 — etfs dep 불필요 (렌더마다 새 배열 생성 방지)
   // 최적화: coins 탭이 아닐 때 WS 틱으로 coins가 변해도 tabItems 재계산 방지
   // → activeCoinData: coin 탭일 때만 coins 참조, 아닐 때 undefined (stable)
   const activeCoinData = activeTab === 'coin' ? coins : undefined;
@@ -287,10 +308,10 @@ export default function App() {
       case 'kr':   return krStocks;
       case 'us':   return usStocks;
       case 'coin': return activeCoinData ?? [];
-      case 'etf':  return ETF_ITEMS;
+      case 'etf':  return etfItems;
       default:     return krStocks;
     }
-  }, [activeTab, krStocks, usStocks, activeCoinData]);
+  }, [activeTab, krStocks, usStocks, activeCoinData, etfItems]);
 
   const allStocks = useMemo(() => [...krStocks, ...usStocks], [krStocks, usStocks]);
 
@@ -400,7 +421,7 @@ export default function App() {
           krStocks={krStocks}
           usStocks={usStocks}
           coins={coins}
-          etfs={ETF_ITEMS}
+          etfs={etfItems}
           krwRate={krwRate}
           onSelect={setSelectedItem}
           onClose={() => setSearchOpen(false)}

--- a/src/api/news.js
+++ b/src/api/news.js
@@ -45,33 +45,41 @@ function timeAgo(dateInput) {
 
 // ─── 뉴스 제목에서 언론사명 중복 제거 (출처는 source 필드에 이미 있음) ──────
 // 한국어 언론사명 목록 — Google News RSS가 제목 끝에 " - 언론사명" 형태로 붙임
+// 줄임말·변형도 포함
 const KR_SOURCE_STRIP = [
-  '글로벌이코노믹','한국경제','매일경제','조선비즈','조선일보','동아일보','중앙일보',
-  '헤럴드경제','연합뉴스','뉴시스','뉴스1','머니투데이','파이낸셜뉴스','서울경제',
-  '이데일리','아시아경제','이투데이','비즈니스포스트','블록미디어','데일리안',
-  '국민일보','세계일보','문화일보','경향신문','한겨레','한국일보','시사저널',
-  '코인데스크','코인텔레그래프','블록스트리트','팍스넷','디지털타임스','전자신문',
-  'ZDNet Korea','ZDNet','ZDNET','Investing.com','Reuters','Bloomberg','CNBC',
+  '글로벌이코노믹','한국경제','한경','한경닷컴','매일경제','매경','조선비즈','조선일보',
+  '동아일보','동아','중앙일보','중앙','헤럴드경제','헤럴드','연합뉴스','연합','뉴시스','뉴스1',
+  '머니투데이','머니S','파이낸셜뉴스','파이낸셜','서울경제','서울신문',
+  '이데일리','아시아경제','아시아타임즈','이투데이','비즈니스포스트','블록미디어','데일리안',
+  '국민일보','세계일보','문화일보','경향신문','한겨레','한국일보','시사저널','시사IN',
+  '코인데스크','코인텔레그래프','코인리더스','블록스트리트','팍스넷',
+  '디지털타임스','전자신문','IT조선','IT동아','테크크런치','테크플러스',
+  '뉴스핌','더벨','인포스탁','인베스팅닷컴','NSP통신','노컷뉴스','오마이뉴스',
+  'ZDNet Korea','ZDNet','ZDNET',
+  'Investing.com','Reuters','Bloomberg','CNBC','MarketWatch','Yahoo Finance',
+  'Decrypt','CoinDesk','CoinTelegraph','The Block','Blockworks',
+  'Business Wire','PR Newswire','GlobeNewswire','BusinessPost',
 ];
 
 function cleanTitle(title, sourceName) {
   let t = title;
-  // 파이프 뒤 언론사명 제거 "제목 | Reuters"
+  // 파이프 뒤 언론사명 제거 "제목 | Reuters" or "제목 | 한국경제"
   t = t.replace(/\s*\|.*$/, '');
-  // 영어 언론사명 끝부분 제거 "제목 - Reuters"
+  // 영어 언론사명 끝부분 제거 "제목 - Reuters" (대소문자 무관)
   t = t.replace(/\s*[-–]\s*[A-Z][a-zA-Z\s.]+$/, '');
-  // 대괄호 접두사 제거 "[Reuters] 제목"
-  t = t.replace(/^\[.*?\]\s*/, '');
-  // 소스명 접두사 제거
+  // 대괄호/소괄호 접두사 제거 "[Reuters] 제목" "【연합뉴스】 제목"
+  t = t.replace(/^[\[【\(].*?[\]】\)]\s*/, '');
+  // 소스명 접두사 제거 "Reuters: 제목"
   t = t.replace(new RegExp(`^${sourceName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*[-–:]\\s*`, 'i'), '');
   // 영문 프리픽스 제거
   t = t.replace(/^(UPDATE \d+-|CORRECTED-|EXCLUSIVE-|ANALYSIS-|BREAKINGVIEWS-|REFILE-)/i, '');
-  // 한국어 언론사명 스트립 — " - 언론사명" 패턴
+  // 한국어 언론사명 스트립 — " - 언론사명" 또는 " | 언론사명" 패턴
   for (const src of KR_SOURCE_STRIP) {
-    t = t.replace(new RegExp(`\\s*[-–|]\\s*${src.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'i'), '');
+    const escaped = src.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    t = t.replace(new RegExp(`\\s*[-–|]\\s*${escaped}\\s*$`, 'i'), '');
   }
-  // 일반 패턴: 끝부분 " - 짧은텍스트(15자 이하)" 제거 — 언론사명은 주로 짧음
-  t = t.replace(/\s+[-–]\s+([^\s].{0,14})$/, (match, stripped) => {
+  // 일반 패턴: 끝부분 " - 짧은텍스트(20자 이하)" 제거 — 언론사명은 주로 짧음
+  t = t.replace(/\s+[-–]\s+([^\s].{0,19})$/, (match, stripped) => {
     // 숫자나 퍼센트가 포함된 경우 뉴스 내용의 일부일 수 있으므로 유지
     if (/[\d%]/.test(stripped)) return match;
     return '';
@@ -267,19 +275,45 @@ async function fetchUsNews() {
   return items;
 }
 
-// [국장] Google News (자체 프록시)
+// [국장] Google News — 멀티쿼리로 섹터 + 개별 주요 종목 커버
+const KR_STOCK_NEWS_QUERIES = [
+  {
+    // 국장 전반 + 삼성전자·SK하이닉스 (반도체)
+    url: 'https://news.google.com/rss/search?q=%EC%BD%94%EC%8A%A4%ED%94%BC+%EC%BD%94%EC%8A%A4%EB%8B%A5+%EC%A6%9D%EC%8B%9C+%EC%A3%BC%EC%8B%9D+%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90+SK%ED%95%98%EC%9D%B4%EB%8B%89%EC%8A%A4&hl=ko&gl=KR&ceid=KR:ko',
+    source: '구글뉴스',
+  },
+  {
+    // 배터리·전기차·2차전지 (LG에너지솔루션, 삼성SDI, SK이노, 포스코퓨처엠, 에코프로)
+    url: 'https://news.google.com/rss/search?q=%EB%B0%B0%ED%84%B0%EB%A6%AC+2%EC%B0%A8%EC%A0%84%EC%A7%80+%EC%A0%84%EA%B8%B0%EC%B0%A8+%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C+%ED%8F%AC%EC%8A%A4%EC%BD%94&hl=ko&gl=KR&ceid=KR:ko',
+    source: '구글뉴스',
+  },
+  {
+    // 바이오·제약·헬스케어 (삼성바이오, 셀트리온, 알테오젠, 한미약품)
+    url: 'https://news.google.com/rss/search?q=%EB%B0%94%EC%9D%B4%EC%98%A4+%EC%A0%9C%EC%95%BD+%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8+%ED%95%9C%EB%AF%B8%EC%95%BD%ED%92%88+%EC%95%8C%ED%85%8C%EC%98%A4%EC%A0%A0&hl=ko&gl=KR&ceid=KR:ko',
+    source: '구글뉴스',
+  },
+  {
+    // 자동차·조선·방산·IT (현대차, 기아, 한화에어로, 현대중공업, NAVER, 카카오)
+    url: 'https://news.google.com/rss/search?q=%ED%98%84%EB%8C%80%EC%B0%A8+%EA%B8%B0%EC%95%84+%ED%95%9C%ED%99%94%EC%97%90%EC%96%B4%EB%A1%9C+%EC%A1%B0%EC%84%A0+NAVER+%EC%B9%B4%EC%B9%B4%EC%98%A4&hl=ko&gl=KR&ceid=KR:ko',
+    source: '구글뉴스',
+  },
+];
+
 async function fetchKrNews() {
   const cached = cacheGet('kr');
   if (cached?.fresh) return cached.data;
 
-  const googleItems = await fetchRSS(
-    'https://news.google.com/rss/search?q=%EC%BD%94%EC%8A%A4%ED%94%BC+%EC%BD%94%EC%8A%A4%EB%8B%A5+%EC%A6%9D%EC%8B%9C+%EC%A3%BC%EC%8B%9D+%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90&hl=ko&gl=KR&ceid=KR:ko',
-    'kr', '구글뉴스',
+  // 4개 쿼리 병렬 취득 (각 섹터 커버)
+  const results = await Promise.allSettled(
+    KR_STOCK_NEWS_QUERIES.map(({ url, source }) =>
+      fetchRSS(url, 'kr', source)
+    )
   );
+  const allItems = results.flatMap(r => r.status === 'fulfilled' ? r.value : []);
 
-  const items = dedup(googleItems.filter(isFinancialNews).filter(isRecentNews))
+  const items = dedup(allItems.filter(isFinancialNews).filter(isRecentNews))
     .sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate))
-    .slice(0, 30);
+    .slice(0, 50);
 
   if (items.length > 0) cacheSet('kr', items);
   else if (cached?.data) return cached.data.filter(isRecentNews);

--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -511,7 +511,7 @@ export default function HomeDashboard({
     }, {});
   }, [surgeItems, recentNews]);
 
-  // ─── SECTION 3: 각 시장별 HOT TOP5 ────────────────────────
+  // ─── SECTION 3: 각 시장별 HOT TOP5 (급등/급락) ─────────────
   const krHot = useMemo(
     () => [...krItems].sort((a, b) => getPct(b) - getPct(a)).slice(0, 5),
     [krItems]
@@ -522,6 +522,19 @@ export default function HomeDashboard({
   );
   const coinHot = useMemo(
     () => [...coinItems].sort((a, b) => getPct(b) - getPct(a)).slice(0, 5),
+    [coinItems]
+  );
+  // 급락 TOP5 (낙폭 큰 순)
+  const krDrop = useMemo(
+    () => [...krItems].sort((a, b) => getPct(a) - getPct(b)).slice(0, 5),
+    [krItems]
+  );
+  const usDrop = useMemo(
+    () => [...usItems].sort((a, b) => getPct(a) - getPct(b)).slice(0, 5),
+    [usItems]
+  );
+  const coinDrop = useMemo(
+    () => [...coinItems].sort((a, b) => getPct(a) - getPct(b)).slice(0, 5),
     [coinItems]
   );
 
@@ -803,6 +816,84 @@ export default function HomeDashboard({
                     />
                   ))
                 : <div className="px-4 py-6 text-center text-[12px] text-[#B0B8C1]">데이터 로딩 중</div>
+            }
+          </div>
+        </div>
+      </div>
+
+      {/* ─── SECTION 3b: 3열 DROP 리스트 (급락 TOP5) ──────── */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {/* 국내 급락 */}
+        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13px]">🇰🇷</span>
+              <span className="text-[13px] font-bold text-[#191F28]">국내 급락</span>
+            </div>
+            <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED]">TOP 5</span>
+          </div>
+          <div className="py-1">
+            {!hasData
+              ? <SkeletonHotRow count={5} />
+              : krDrop.map((item, i) => (
+                  <HotRow
+                    key={`kr-drop-${item.symbol}`}
+                    item={item}
+                    rank={i + 1}
+                    krwRate={krwRate}
+                    onClick={onItemClick}
+                  />
+                ))
+            }
+          </div>
+        </div>
+
+        {/* 미장 급락 */}
+        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13px]">🇺🇸</span>
+              <span className="text-[13px] font-bold text-[#191F28]">미장 급락</span>
+            </div>
+            <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED]">TOP 5</span>
+          </div>
+          <div className="py-1">
+            {!hasData
+              ? <SkeletonHotRow count={5} />
+              : usDrop.map((item, i) => (
+                  <HotRow
+                    key={`us-drop-${item.symbol}`}
+                    item={item}
+                    rank={i + 1}
+                    krwRate={krwRate}
+                    onClick={onItemClick}
+                  />
+                ))
+            }
+          </div>
+        </div>
+
+        {/* 코인 급락 */}
+        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13px]">🪙</span>
+              <span className="text-[13px] font-bold text-[#191F28]">코인 급락</span>
+            </div>
+            <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED]">TOP 5</span>
+          </div>
+          <div className="py-1">
+            {!hasData
+              ? <SkeletonHotRow count={5} />
+              : coinDrop.map((item, i) => (
+                  <HotRow
+                    key={`coin-drop-${item.symbol}`}
+                    item={item}
+                    rank={i + 1}
+                    krwRate={krwRate}
+                    onClick={onItemClick}
+                  />
+                ))
             }
           </div>
         </div>

--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -1,6 +1,6 @@
-// 급등 ticker 배너 — 상단 sticky
-// 급등(>=3%) 종목만 표시, 없으면 상위 5개
-// 급등 있을 때: 어두운 배경 + 빨간 강조
+// 급등/급락 ticker 배너 — 상단 sticky
+// 급등(>=3%) + 급락(<=-3%) 종목 표시, 없으면 상위 5개 (절댓값 기준)
+// 급등/급락 있을 때: 어두운 배경 강조
 // 없을 때: 중립 배경
 import { memo, useMemo } from 'react';
 
@@ -25,12 +25,21 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick
         market: 'coin',
         _raw:   c,
       })),
-    ].sort((a, b) => b.pct - a.pct);
+    ];
 
-    const hot = all.filter(i => i.pct >= 3);
-    const hasHot = hot.length > 0;
-    // 급등 있으면 급등만 최대 20개, 없으면 상위 5개 (250개 코인 확장 후 너무 많아지는 방지)
-    const base = hasHot ? hot.slice(0, 20) : all.slice(0, 5);
+    // 급등 (pct >= 3): 등락률 내림차순, 급락 (pct <= -3): 낙폭 내림차순(절댓값)
+    const surges = all.filter(i => i.pct >= 3).sort((a, b) => b.pct - a.pct);
+    const drops  = all.filter(i => i.pct <= -3).sort((a, b) => a.pct - b.pct);
+    const hasHot = surges.length > 0 || drops.length > 0;
+
+    let base;
+    if (hasHot) {
+      // 급등 최대 10개 + 급락 최대 10개 (총 최대 20개)
+      base = [...surges.slice(0, 10), ...drops.slice(0, 10)];
+    } else {
+      // 급등/급락 없으면 절댓값 상위 5개
+      base = [...all].sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct)).slice(0, 5);
+    }
     // 무한 스크롤 효과를 위해 2배 복제
     return { items: [...base, ...base], hasHot };
   }, [stocks, coins]);
@@ -61,7 +70,7 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick
           className="text-[10px] font-bold tracking-widest uppercase"
           style={{ color: hasHot ? 'rgba(255,107,119,0.9)' : 'rgba(255,255,255,0.35)' }}
         >
-          {hasHot ? '🔥 급등' : '시세'}
+          {hasHot ? '🔥 급등·급락' : '시세'}
         </span>
       </div>
 
@@ -88,11 +97,15 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick
               style={{
                 background: item.pct >= 3
                   ? 'rgba(240,68,82,0.2)'
+                  : item.pct <= -3
+                  ? 'rgba(23,100,237,0.25)'
                   : item.pct > 0
                   ? 'rgba(42,199,105,0.15)'
                   : 'rgba(255,255,255,0.08)',
                 color: item.pct >= 3
                   ? '#FF6B77'
+                  : item.pct <= -3
+                  ? '#5B9CF6'
                   : item.pct > 0
                   ? '#2AC769'
                   : 'rgba(255,255,255,0.45)',

--- a/src/data/relatedAssets.js
+++ b/src/data/relatedAssets.js
@@ -550,6 +550,30 @@ export const RELATED_ASSETS = {
     ],
   },
 
+  // 삼성전기 (코스피 009150)
+  '009150': {
+    label: '삼성전기',
+    sector: '전자부품',
+    related: [
+      { symbol: '005930',  type: 'sector', reason: '삼성전자 (모회사 · MLCC 최대 고객)', market: 'KR' },
+      { symbol: '011070',  type: 'sector', reason: 'LG이노텍 (MLCC 경쟁)',               market: 'KR' },
+      { symbol: 'AAPL',    type: 'customer', reason: '애플 (삼성전기 주요 고객)',         market: 'US' },
+      { symbol: 'AVGO',    type: 'sector',   reason: '브로드컴 (부품 수요 연관)',          market: 'US' },
+      { symbol: 'QCOM',    type: 'sector',   reason: '퀄컴 (모바일 부품 연관)',            market: 'US' },
+    ],
+  },
+  '삼성전기': {
+    label: '삼성전기',
+    sector: '전자부품',
+    related: [
+      { symbol: '005930',  type: 'sector', reason: '삼성전자 (모회사 · MLCC 최대 고객)', market: 'KR' },
+      { symbol: '011070',  type: 'sector', reason: 'LG이노텍 (MLCC 경쟁)',               market: 'KR' },
+      { symbol: 'AAPL',    type: 'customer', reason: '애플 (삼성전기 주요 고객)',         market: 'US' },
+      { symbol: 'AVGO',    type: 'sector',   reason: '브로드컴 (부품 수요 연관)',          market: 'US' },
+      { symbol: 'QCOM',    type: 'sector',   reason: '퀄컴 (모바일 부품 연관)',            market: 'US' },
+    ],
+  },
+
   // SK하이닉스 (코스피 코드 000660)
   '000660': {
     label: 'SK하이닉스',
@@ -870,16 +894,48 @@ export function getRelatedTickers(symbol) {
  */
 export function findRelatedItems(symbol, dataMap, limit = 6) {
   const related = getRelatedAssets(symbol);
-  if (!related.length) return [];
 
-  return related
+  // ── 하드코딩 연관 종목 있으면 우선 사용 ──────────────────────
+  if (related.length) {
+    return related
+      .slice(0, limit)
+      .map(r => ({
+        ticker: r.symbol,
+        type:   r.type,
+        reason: r.reason,
+        market: r.market,
+        isEtf:  r.type === RELATION_TYPES.ETF,
+        item:   dataMap[r.symbol] || null,
+      }));
+  }
+
+  // ── Fallback: 섹터 기반 자동 연관 종목 ───────────────────────
+  // dataMap 내 현재 종목 찾기 (심볼 or 이름 매칭)
+  const currentItem = dataMap[symbol];
+  if (!currentItem) return [];
+
+  const currentSector = currentItem.sector;
+  const currentMarket = currentItem.market;
+  if (!currentSector) return [];
+
+  // 같은 섹터의 다른 종목을 최대 limit개 반환
+  const sectorPeers = Object.values(dataMap)
+    .filter(item =>
+      item &&
+      item.sector === currentSector &&
+      item.market === currentMarket &&
+      (item.symbol || item.id) !== symbol &&
+      item.name !== symbol
+    )
     .slice(0, limit)
-    .map(r => ({
-      ticker: r.symbol,
-      type:   r.type,
-      reason: r.reason,
-      market: r.market,
-      isEtf:  r.type === RELATION_TYPES.ETF,
-      item:   dataMap[r.symbol] || null,
+    .map(item => ({
+      ticker: item.symbol || item.id || '',
+      type:   'sector',
+      reason: `같은 섹터 (${currentSector})`,
+      market: currentMarket?.toUpperCase() || '',
+      isEtf:  false,
+      item,
     }));
+
+  return sectorPeers;
 }

--- a/src/hooks/useNewsQuery.js
+++ b/src/hooks/useNewsQuery.js
@@ -71,18 +71,25 @@ export function useStockNews(symbol, name) {
 
   const news = useMemo(() => {
     if (!symbol || !allNews.length) return [];
-    // 영문명이 너무 길면 첫 단어만 사용 (예: "Apple" not "Apple Inc.")
+
+    // 키워드 구성: symbol + 종목명 + 첫 단어 (영문명 "Apple Inc." → "apple")
     const shortName = name ? name.split(/[\s\/]/)[0] : null;
-    const keywords = [symbol, name, shortName]
-      .filter(Boolean)
+    const rawKeywords = [symbol, name, shortName].filter(Boolean);
+
+    // 6자리 숫자 심볼(국장)은 키워드로 쓰면 거짓 양성 많음 — 제외
+    const keywords = rawKeywords
       .map(k => k.toLowerCase())
+      .filter(k => k.length >= 2 && !/^\d{6}$/.test(k)) // 국장 코드 제외
       .filter((k, i, arr) => arr.indexOf(k) === i); // 중복 제거
+
+    if (!keywords.length) return [];
+
     return allNews
       .filter(item => {
         const text = (item.title + ' ' + (item.summary || item.description || '')).toLowerCase();
-        return keywords.some(kw => kw.length >= 2 && text.includes(kw));
+        return keywords.some(kw => text.includes(kw));
       })
-      .slice(0, 6);
+      .slice(0, 8); // 6 → 8개로 확대
   }, [symbol, name, allNews]);
 
   return { news, isLoading };


### PR DESCRIPTION
## Summary
- **급락 TOP5 섹션** 홈 대시보드 추가 (국내/미장/코인 3열) + SurgeBanner 급락 파란색 표시
- **연관 종목 자동 매칭**: RELATED_ASSETS 미등록 종목 → 같은 섹터 종목 자동 fallback
- **뉴스 커버리지 확대**: 국장 뉴스 단일 쿼리 → 4개 섹터 쿼리 병렬 (반도체/배터리/바이오/자동차)
- **ETF 실시간 가격**: static mock → Yahoo Finance 60초 폴링
- **뉴스 제목 클리닝**: 언론사명 줄임말/변형 패턴 추가

## Test plan
- [ ] 홈에서 국내/미장/코인 급락 TOP5 섹션 확인
- [ ] SurgeBanner에 급락 종목 파란색으로 표시 확인
- [ ] 삼성전기 클릭 → 연관 종목 (삼성전자, LG이노텍, 애플 등) 표시 확인
- [ ] 임의 종목 클릭 → 연관 종목 없어도 같은 섹터 종목 자동 표시 확인
- [ ] ETF 탭 가격 실시간 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)