### PR TITLE
fix: 국내주식 차트 한투 API로 교체 (Yahoo .KS 404 해결)

### DIFF
--- a/api/hantoo-chart.js
+++ b/api/hantoo-chart.js
@@ -1,0 +1,79 @@
+// 한투 Open API — 국장 주가 OHLCV 차트 데이터 Vercel serverless
+//
+// 요청: GET /api/hantoo-chart?symbol=005930&period=D&count=100
+// 응답: { data: [ { date, open, high, low, close, volume } ] }
+//
+// period: D=일봉, W=주봉, M=월봉
+// 일봉 최대 ~100일 (KIS API 1회 응답 한도)
+
+import { getHantooToken, HANTOO_BASE } from './_hantoo-token.js';
+
+export default async function handler(req, res) {
+  if (!process.env.HANTOO_APP_KEY || !process.env.HANTOO_APP_SECRET) {
+    return res.status(503).json({ error: 'HANTOO not configured' });
+  }
+
+  const { symbol, period = 'D' } = req.query;
+  if (!symbol || !/^\d{6}$/.test(symbol)) {
+    return res.status(400).json({ error: 'symbol required (6-digit KR code)' });
+  }
+
+  const validPeriod = ['D', 'W', 'M'].includes(period) ? period : 'D';
+
+  // 기간 계산 — 일봉 5개월, 주봉 1년, 월봉 5년
+  const endDate = new Date();
+  const startDate = new Date();
+  if (validPeriod === 'D') startDate.setMonth(startDate.getMonth() - 5);
+  else if (validPeriod === 'W') startDate.setFullYear(startDate.getFullYear() - 1);
+  else startDate.setFullYear(startDate.getFullYear() - 5);
+
+  const fmt = d => d.toISOString().slice(0, 10).replace(/-/g, '');
+
+  try {
+    const token = await getHantooToken();
+
+    const url = new URL(`${HANTOO_BASE}/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice`);
+    url.searchParams.set('FID_COND_MRKT_DIV_CODE', 'J');
+    url.searchParams.set('FID_INPUT_ISCD', symbol);
+    url.searchParams.set('FID_INPUT_DATE_1', fmt(startDate));
+    url.searchParams.set('FID_INPUT_DATE_2', fmt(endDate));
+    url.searchParams.set('FID_PERIOD_DIV_CODE', validPeriod);
+
+    const apiRes = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        appkey:        process.env.HANTOO_APP_KEY,
+        appsecret:     process.env.HANTOO_APP_SECRET,
+        tr_id:         'FHKST03010100',
+        custtype:      'P',
+      },
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!apiRes.ok) throw new Error(`KIS HTTP ${apiRes.status}`);
+    const data = await apiRes.json();
+    if (data.rt_cd !== '0') throw new Error(data.msg1 || `KIS rt_cd ${data.rt_cd}`);
+
+    // output2: 일별 OHLCV 배열 (최신순 → 오래된 순 내림차순이므로 reverse)
+    const candles = (data.output2 || [])
+      .map(r => ({
+        date:   r.stck_bsop_date,                // YYYYMMDD
+        open:   parseInt(r.stck_oprc  || '0', 10),
+        high:   parseInt(r.stck_hgpr  || '0', 10),
+        low:    parseInt(r.stck_lwpr  || '0', 10),
+        close:  parseInt(r.stck_clpr  || '0', 10),
+        volume: parseInt(r.acml_vol   || '0', 10),
+      }))
+      .filter(c => c.close > 0)
+      .reverse(); // 오래된 → 최신 순 정렬
+
+    if (!candles.length) throw new Error('캔들 데이터 없음');
+
+    // 캐시: 일봉 60초, 주봉/월봉 5분
+    const maxAge = validPeriod === 'D' ? 60 : 300;
+    res.setHeader('Cache-Control', `s-maxage=${maxAge}, stale-while-revalidate=30`);
+    res.json({ data: candles });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+}

--- a/src/api/chart.js
+++ b/src/api/chart.js
@@ -51,6 +51,28 @@ function parseYahooChart(data, isIntraday = false) {
   return cleanCandles(candles);
 }
 
+// ─── 한투 API 차트 (국내 주식 일/주/월봉) ────────────────────
+// Yahoo .KS 404 대체 — KIS API로 실제 OHLCV 취득
+async function fetchHantooCandles(symbol, periodCode = 'D') {
+  const res = await fetch(
+    `/api/hantoo-chart?symbol=${encodeURIComponent(symbol)}&period=${periodCode}`,
+    { signal: AbortSignal.timeout(10000) }
+  );
+  if (!res.ok) throw new Error(`hantoo-chart ${res.status}`);
+  const json = await res.json();
+  if (!json.data?.length) throw new Error('hantoo-chart: 데이터 없음');
+
+  return json.data.map(c => ({
+    // YYYYMMDD → 'YYYY-MM-DD'
+    time:   `${c.date.slice(0,4)}-${c.date.slice(4,6)}-${c.date.slice(6,8)}`,
+    open:   c.open,
+    high:   c.high,
+    low:    c.low,
+    close:  c.close,
+    volume: c.volume,
+  }));
+}
+
 // ─── Yahoo Finance v8 차트 (주식 캔들) ───────────────────────
 export async function fetchStockCandles(symbol, range = '1mo', interval = '1d') {
   const isIntraday = ['5m','15m','30m','60m','90m','1h'].includes(interval);
@@ -150,7 +172,23 @@ export async function fetchCandles(item, periodKey = '5분') {
     }
   }
 
-  // 주식: Yahoo Finance (한국 .KS suffix, 미국 그대로)
-  const sym = item.market === 'kr' ? `${item.symbol}.KS` : item.symbol;
-  return fetchStockCandles(sym, range, interval);
+  // 국내 주식: 일/주/월봉은 한투 API 우선 (Yahoo .KS 404 대체)
+  // 분봉/시봉(intraday)은 Yahoo fallback (한투 분봉 API는 별도 구현 필요)
+  if (item.market === 'kr') {
+    if (!isIntraday) {
+      // 일봉=D, 주봉=W, 월봉=M 매핑
+      const periodMap = { '1d': 'D', '1wk': 'W', '1mo': 'M' };
+      const periodCode = periodMap[interval] ?? 'D';
+      try {
+        return await fetchHantooCandles(item.symbol, periodCode);
+      } catch {
+        // 한투 실패 시 Yahoo fallback
+      }
+    }
+    const sym = `${item.symbol}.KS`;
+    return fetchStockCandles(sym, range, interval);
+  }
+
+  // 미국 주식: Yahoo Finance 그대로
+  return fetchStockCandles(item.symbol, range, interval);
 }


### PR DESCRIPTION
## 문제
- `api/chart-proxy.js`가 Yahoo Finance `.KS` 심볼을 요청 → HTTP 404
- 국내 주식 차트 패널에서 모든 종목 차트 불러오기 실패

## 해결
- `api/hantoo-chart.js` 신규 생성
  - KIS `inquire-daily-itemchartprice` API 사용
  - 일봉(D) / 주봉(W) / 월봉(M) 지원
  - 기존 HANTOO_APP_KEY / HANTOO_APP_SECRET Vercel 환경변수 재활용
- `src/api/chart.js` 수정
  - 국내 주식 비인트라데이(일/주/월봉) → `/api/hantoo-chart` 우선
  - 한투 실패 시 Yahoo `.KS` fallback 유지
  - 분봉/시봉(intraday)은 기존 Yahoo 경로 유지

## 테스트 범위
- 삼성전자(005930) 일봉 차트 정상 렌더링 확인 필요
- Vercel HANTOO_APP_KEY 확인 완료 (이전 테스트에서 working 검증)