### PR TITLE
feat: 데이터 신뢰도 배지 + API 에러 상태 UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ export default function App() {
   const [krwRate, setKrwRate]             = useState(1466);
   const [lastUpdated, setLastUpdated]     = useState(null);
   const [loading, setLoading]             = useState(false);
+  const [dataErrors, setDataErrors]       = useState({ kr: false, us: false, coin: false });
   const [selectedItem, setSelectedItem]   = useState(null);
   const [searchOpen, setSearchOpen]       = useState(false);
   // 알림 권한 차단 시 복구 배너 표시 여부
@@ -83,8 +84,12 @@ export default function App() {
           const old = prev.find(p => p.id === c.id);
           return { ...c, sparkline: c.sparkline?.length ? c.sparkline : old?.sparkline ?? [] };
         }));
+        setDataErrors(prev => ({ ...prev, coin: false }));
       }
-    } catch (e) { console.warn('코인 전체갱신 실패 (캐시 사용):', e.message); }
+    } catch (e) {
+      console.warn('코인 전체갱신 실패 (캐시 사용):', e.message);
+      setDataErrors(prev => ({ ...prev, coin: true }));
+    }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── 미장 갱신 (30초) ────────────────────────────────────────
@@ -97,8 +102,12 @@ export default function App() {
           return u?.price ? { ...s, ...u, sparkline: u.sparkline?.length ? u.sparkline : s.sparkline } : s;
         }));
         checkAndAlertBatch(data, 'us');
+        setDataErrors(prev => ({ ...prev, us: false }));
       }
-    } catch (e) { console.warn('미장 갱신 실패:', e.message); }
+    } catch (e) {
+      console.warn('미장 갱신 실패:', e.message);
+      setDataErrors(prev => ({ ...prev, us: true }));
+    }
   }, []);
 
   // ── ETF 실시간 갱신 (60초) ──────────────────────────────────
@@ -127,8 +136,12 @@ export default function App() {
           return u?.price ? { ...s, ...u, sparkline: [...s.sparkline.slice(1), u.price] } : s;
         }));
         checkAndAlertBatch(data, 'kr');
+        setDataErrors(prev => ({ ...prev, kr: false }));
       }
-    } catch (e) { console.warn('국장 갱신 실패:', e.message); }
+    } catch (e) {
+      console.warn('국장 갱신 실패:', e.message);
+      setDataErrors(prev => ({ ...prev, kr: true }));
+    }
   }, []);
 
   // ── 지수 갱신 (60초) ────────────────────────────────────────
@@ -390,6 +403,16 @@ export default function App() {
                 krwRate={krwRate}
                 onRowClick={setSelectedItem}
                 loading={loading}
+                dataError={
+                  activeTab === 'kr'   ? dataErrors.kr :
+                  activeTab === 'us'   ? dataErrors.us :
+                  activeTab === 'coin' ? dataErrors.coin : false
+                }
+                onRetry={
+                  activeTab === 'kr'   ? refreshKoreanStocks :
+                  activeTab === 'us'   ? refreshUsStocks :
+                  activeTab === 'coin' ? refreshCoins : undefined
+                }
               />
             </>
           )}

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -318,7 +318,15 @@ function MarketStatusBadge({ type }) {
 }
 
 // ─── 메인 컴포넌트 ───────────────────────────────────────────
-export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466, onRowClick, loading = false }) {
+// ─── 데이터 신뢰도 배지 ─────────────────────────────────────
+const RELIABILITY = {
+  kr:   { label: '● LIVE', sub: '한국투자증권',  color: '#2AC769' },
+  us:   { label: '⏱ 15분 지연', sub: 'Yahoo Finance', color: '#FF9500' },
+  coin: { label: '● LIVE', sub: 'Upbit WebSocket', color: '#2AC769' },
+  etf:  { label: '⏱ 15분 지연', sub: 'Yahoo Finance', color: '#FF9500' },
+};
+
+export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466, onRowClick, loading = false, dataError = null, onRetry }) {
   const [sortKey, setSortKey] = useState('changePct');
   const [sortDir, setSortDir] = useState('desc');
   const [search,  setSearch]  = useState('');
@@ -425,8 +433,39 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = 1466
     ));
   };
 
+  const reliability = RELIABILITY[type];
+
   return (
     <div className="bg-white rounded-2xl overflow-hidden shadow-sm">
+      {/* 데이터 신뢰도 + 에러 상태 배너 */}
+      {(reliability || dataError) && (
+        <div className={`flex items-center justify-between px-4 py-2 border-b border-[#F2F4F6] ${dataError ? 'bg-[#FFF8E1]' : 'bg-[#FAFBFC]'}`}>
+          {dataError ? (
+            <>
+              <div className="flex items-center gap-2">
+                <span className="text-[13px]">⚠️</span>
+                <span className="text-[12px] text-[#7B5D00] font-medium">데이터 불러오기 실패 — 이전 데이터를 표시하고 있어요</span>
+              </div>
+              {onRetry && (
+                <button
+                  onClick={onRetry}
+                  className="text-[12px] text-[#3182F6] font-semibold px-3 py-1 rounded-lg hover:bg-[#EDF4FF] transition-colors flex-shrink-0"
+                >
+                  재시도
+                </button>
+              )}
+            </>
+          ) : reliability && (
+            <div className="flex items-center gap-2 ml-auto">
+              <span className="text-[11px] font-semibold" style={{ color: reliability.color }}>
+                {reliability.label}
+              </span>
+              <span className="text-[10px] text-[#C9CDD2]">{reliability.sub}</span>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* 코인 탭 전용: BTC 도미넌스 + 전체 시총 통계 바 */}
       {coinMarketStats && (
         <div className="flex items-center gap-0 px-4 py-2.5 border-b border-[#F2F4F6] bg-[#FAFBFC] overflow-x-auto no-scrollbar">


### PR DESCRIPTION
## 변경사항

### P0-2: 데이터 신뢰도 레이블
- 국장 탭 / 코인 탭: `● LIVE` 초록 배지
- 미장 탭 / ETF 탭: `⏱ 15분 지연` 주황 배지
- 각 탭 우상단에 데이터 출처 표시 (한투/Upbit WS/Yahoo Finance)

### P0-4: API 에러 상태 UI
- 국장/미장/코인 갱신 실패 시 `dataErrors.{kr|us|coin} = true`
- WatchlistTable에 노란 경고 배너 표시: "데이터 불러오기 실패 — 이전 데이터를 표시하고 있어요"
- 재시도 버튼 클릭 시 해당 갱신 함수 재호출
- 갱신 성공 시 에러 배너 자동 해제