### PR TITLE
fix: 미장 changePct=0 수정 + 지수 서버사이드 프록시

### DIFF
--- a/api/market-indices.js
+++ b/api/market-indices.js
@@ -1,0 +1,82 @@
+// api/market-indices.js — 시장 지수 Vercel Edge 프록시
+// allorigins 경유 없이 서버사이드에서 Yahoo Finance 직접 호출
+// KOSPI: Stooq 1순위 (빠름), Yahoo fallback
+// KOSDAQ + 해외: Yahoo v8 직접 호출
+export const config = { runtime: 'edge' };
+
+const INDICES = [
+  { id: 'KOSDAQ', symbol: '^KQ11'    },
+  { id: 'SPX',    symbol: '^GSPC'    },
+  { id: 'NDX',    symbol: '^IXIC'    },
+  { id: 'DJI',    symbol: '^DJI'     },
+  { id: 'DXY',    symbol: 'DX-Y.NYB' },
+];
+
+async function fetchYahooIndex(id, symbol) {
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=5d&includePrePost=false`;
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'Mozilla/5.0 (compatible)', 'Accept': 'application/json' },
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!res.ok) throw new Error(`Yahoo ${id} ${res.status}`);
+  const data   = await res.json();
+  const result = data?.chart?.result?.[0];
+  if (!result?.meta?.regularMarketPrice) throw new Error(`no price: ${id}`);
+  const meta   = result.meta;
+  const closes = result.indicators?.quote?.[0]?.close?.filter(Boolean) ?? [];
+  const price  = meta.regularMarketPrice;
+  // chartPreviousClose는 차트 시작 기준점 — 전일 종가 아님, 사용 금지
+  const prev   = meta.previousClose
+    ?? (closes.length >= 2 ? closes[closes.length - 2] : null)
+    ?? price;
+  return {
+    id,
+    value:     parseFloat(price.toFixed(2)),
+    change:    parseFloat((price - prev).toFixed(2)),
+    changePct: parseFloat(((price - prev) / prev * 100).toFixed(2)),
+  };
+}
+
+async function fetchStooqKospi() {
+  const res = await fetch('https://stooq.com/q/l/?s=^kospi&f=sd2t2ohlcvnp&h&e=json', {
+    headers: { 'User-Agent': 'Mozilla/5.0 (compatible)' },
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) throw new Error(`Stooq KOSPI ${res.status}`);
+  const data = await res.json();
+  const s = (data.symbols || []).find(x => x.Close && x.Close !== 'N/D');
+  if (!s) throw new Error('Stooq KOSPI N/D');
+  const close    = parseFloat(s.Close);
+  const prevClose = parseFloat(s.Prev_Close) || 0;
+  return {
+    id:        'KOSPI',
+    value:     parseFloat(close.toFixed(2)),
+    change:    prevClose > 0 ? parseFloat((close - prevClose).toFixed(2)) : 0,
+    changePct: prevClose > 0 ? parseFloat(((close - prevClose) / prevClose * 100).toFixed(2)) : 0,
+  };
+}
+
+export default async function handler(req) {
+  // KOSPI: Stooq 1순위 → Yahoo fallback
+  const kospiPromise = fetchStooqKospi()
+    .catch(() => fetchYahooIndex('KOSPI', '^KS11'));
+
+  // KOSDAQ + 해외: Yahoo 직접 (서버사이드, CORS 무관)
+  const [kospiResult, ...otherResults] = await Promise.allSettled([
+    kospiPromise,
+    ...INDICES.map(({ id, symbol }) => fetchYahooIndex(id, symbol)),
+  ]);
+
+  const results = [
+    ...(kospiResult.status === 'fulfilled' ? [kospiResult.value] : []),
+    ...otherResults.filter(r => r.status === 'fulfilled').map(r => r.value),
+  ];
+
+  return new Response(JSON.stringify({ results }), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, s-maxage=55, stale-while-revalidate=10',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/api/us-price.js
+++ b/api/us-price.js
@@ -4,17 +4,22 @@ export const config = { runtime: 'edge' };
 
 // Yahoo v8 chart — 실시간 1순위
 async function fetchYahooV8(symbol) {
-  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=1d`;
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=5d`;
   const res = await fetch(url, {
     headers: { 'User-Agent': 'Mozilla/5.0 (compatible)', 'Accept': 'application/json' },
     signal: AbortSignal.timeout(6000),
   });
   if (!res.ok) throw new Error(`Yahoo v8 ${res.status}`);
   const data = await res.json();
-  const meta = data?.chart?.result?.[0]?.meta;
-  if (!meta?.regularMarketPrice) throw new Error('no price');
-  const price = meta.regularMarketPrice;
-  const prev  = meta.chartPreviousClose ?? meta.previousClose ?? price;
+  const result = data?.chart?.result?.[0];
+  if (!result?.meta?.regularMarketPrice) throw new Error('no price');
+  const meta   = result.meta;
+  const closes = result.indicators?.quote?.[0]?.close?.filter(Boolean) ?? [];
+  const price  = meta.regularMarketPrice;
+  // chartPreviousClose는 차트 시작 기준점 — 전일 종가 아님, 사용 금지
+  const prev   = meta.previousClose
+    ?? (closes.length >= 2 ? closes[closes.length - 2] : null)
+    ?? price;
   const change    = parseFloat((price - prev).toFixed(2));
   const changePct = prev > 0 ? parseFloat(((price - prev) / prev * 100).toFixed(2)) : 0;
   return {

--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -397,7 +397,16 @@ const ALL_INDICES = [
 ];
 
 export async function fetchIndices() {
-  // KOSPI: Stooq 1순위 → Yahoo fallback
+  // 0) Vercel Edge 프록시 /api/market-indices — 서버사이드 직접 Yahoo 호출 (allorigins 불필요)
+  try {
+    const res = await fetch('/api/market-indices', { signal: AbortSignal.timeout(10000) });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.results?.length >= 5) return data.results;
+    }
+  } catch {}
+
+  // 1) KOSPI: Stooq 1순위 → Yahoo fallback (allorigins 경유)
   const kospiPromise = (async () => {
     try {
       return await fetchStooqKospi();


### PR DESCRIPTION
- api/us-price.js: chartPreviousClose 제거 → closes[-2] 전일종가 패턴
- api/market-indices.js: allorigins 없이 서버사이드 Yahoo 직접 호출
- src/api/stocks.js: fetchIndices() 0순위 /api/market-indices 추가