### PR TITLE
feat: 뉴스 슬라이드 패널 + 관심종목 ★ 토글

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import MarketSummaryBar from './components/MarketSummaryBar';
 import WatchlistTable from './components/WatchlistTable';
 import BreakingNewsPanel from './components/BreakingNewsPanel';
 import ChartSidePanel from './components/ChartSidePanel';
+import NewsSidePanel from './components/NewsSidePanel';
 import HomeDashboard from './components/home';
 import GlobalSearch from './components/GlobalSearch';
 
@@ -40,6 +41,7 @@ export default function App() {
   const [lastUpdated, setLastUpdated]   = useState(null);
   const [loading, setLoading]           = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);
+  const [selectedNews, setSelectedNews] = useState(null);
   const [searchOpen, setSearchOpen]     = useState(false);
   const [notifBanner, setNotifBanner]   = useState(() => {
     const perm = getNotificationPermission();
@@ -173,7 +175,7 @@ export default function App() {
             />
           ) : activeTab === 'news' ? (
             <div className="lg:hidden h-[calc(100vh-112px)]">
-              <BreakingNewsPanel coins={coins} onItemClick={setSelectedItem} />
+              <BreakingNewsPanel coins={coins} onItemClick={setSelectedItem} onNewsClick={setSelectedNews} />
             </div>
           ) : (
             <>
@@ -189,12 +191,15 @@ export default function App() {
         </div>
 
         <div className="hidden lg:block self-start" style={{ position: 'sticky', top: '84px', height: 'calc(100vh - 84px)' }}>
-          <BreakingNewsPanel coins={coins} onItemClick={setSelectedItem} />
+          <BreakingNewsPanel coins={coins} onItemClick={setSelectedItem} onNewsClick={setSelectedNews} />
         </div>
       </div>
 
       {selectedItem && (
         <ChartSidePanel item={selectedItem} krwRate={krwRate} onClose={() => setSelectedItem(null)} onRelatedClick={setSelectedItem} allData={allData} />
+      )}
+      {selectedNews && (
+        <NewsSidePanel news={selectedNews} allData={allData} krwRate={krwRate} onClose={() => setSelectedNews(null)} onRelatedClick={setSelectedItem} />
       )}
       {searchOpen && (
         <GlobalSearch krStocks={krStocks} usStocks={usStocks} coins={coins} etfs={etfItems} krwRate={krwRate} onSelect={setSelectedItem} onClose={() => setSearchOpen(false)} />

--- a/src/components/BreakingNewsPanel.jsx
+++ b/src/components/BreakingNewsPanel.jsx
@@ -41,7 +41,7 @@ const CAT_COLOR = {
   kr:   { bg: '#FFF0F0', color: '#F04452', label: 'KR'   },
 };
 
-function NewsItem({ item }) {
+function NewsItem({ item, onNewsClick }) {
   const cat = CAT_COLOR[item.category] || { bg: '#F2F4F6', color: '#6B7684', label: 'NEWS' };
   // 시그널 태그 추출 — pubDate 전달하여 속보(🔴 속보) 자동 감지, 최대 2개
   const signals = extractNewsSignals(item.title, item.pubDate);
@@ -49,10 +49,8 @@ function NewsItem({ item }) {
   const stockTags = extractStockTags(item.title);
 
   return (
-    <a
-      href={item.link}
-      target="_blank"
-      rel="noopener noreferrer"
+    <div
+      onClick={() => onNewsClick?.(item)}
       className="block px-4 py-3 border-b border-[#F2F4F6] hover:bg-[#FAFBFC] transition-colors cursor-pointer"
     >
       <div className="flex items-center gap-1.5 mb-1.5">
@@ -86,7 +84,7 @@ function NewsItem({ item }) {
           ))}
         </div>
       )}
-    </a>
+    </div>
   );
 }
 
@@ -159,7 +157,7 @@ function getWhalePinInsight(evt) {
   return '대형 지갑 자산 이동 감지';
 }
 
-export default function BreakingNewsPanel({ coins = [], onItemClick }) {
+export default function BreakingNewsPanel({ coins = [], onItemClick, onNewsClick }) {
   const [activeTab, setActiveTab] = useState('all');
   const { data: rawNews = [], isLoading, isError, refetch } = useTabNews(activeTab);
   // 고래 미리보기 핀 — WhalePanel이 이벤트 발행 시 자동 업데이트
@@ -282,7 +280,7 @@ export default function BreakingNewsPanel({ coins = [], onItemClick }) {
             )}
 
             {!isLoading && !isError && news.map(item => (
-              <NewsItem key={item.id} item={item} />
+              <NewsItem key={item.id} item={item} onNewsClick={onNewsClick} />
             ))}
           </>
         )}

--- a/src/components/NewsSidePanel.jsx
+++ b/src/components/NewsSidePanel.jsx
@@ -1,0 +1,209 @@
+// 뉴스 상세 슬라이드 패널 — 요약 + 관련 종목 + 원문 링크
+import { useMemo, useEffect } from 'react';
+import { buildStockKeywords, matchesKeywords } from '../utils/newsAlias';
+
+const CAT_COLOR = {
+  coin: { bg: '#FFF4E6', color: '#FF9500', label: 'COIN' },
+  us:   { bg: '#EDF4FF', color: '#3182F6', label: 'US'   },
+  kr:   { bg: '#FFF0F0', color: '#F04452', label: 'KR'   },
+};
+
+function fmt(n) {
+  if (!n) return '—';
+  if (n >= 1e12) return `${(n/1e12).toFixed(0)}조`;
+  if (n >= 1e8)  return `${(n/1e8).toFixed(0)}억`;
+  return n.toLocaleString('ko-KR');
+}
+
+function RelatedRow({ item, krwRate, onItemClick }) {
+  const isCoin = !!item.id;
+  const pct = isCoin ? (item.change24h ?? 0) : (item.changePct ?? 0);
+  const isUp = pct > 0;
+  const isDown = pct < 0;
+  const color = isUp ? '#F04452' : isDown ? '#1764ED' : '#8B95A1';
+
+  const price = isCoin
+    ? `₩${fmt(Math.round(item.priceKrw || (item.priceUsd ?? 0) * (krwRate || 1466)))}`
+    : item._market === 'KR' || item.market === 'kr'
+      ? `₩${fmt(item.price)}`
+      : `$${(item.price ?? 0).toFixed(2)}`;
+
+  const mktBadge = isCoin
+    ? { label: 'COIN', bg: '#FFF4E6', color: '#FF9500' }
+    : item._market === 'KR' || item.market === 'kr'
+      ? { label: 'KR', bg: '#FFF0F0', color: '#F04452' }
+      : { label: 'US', bg: '#EDF4FF', color: '#3182F6' };
+
+  return (
+    <button
+      onClick={() => onItemClick?.(item)}
+      className="flex items-center justify-between w-full px-4 py-3 hover:bg-[#F7F8FA] transition-colors text-left"
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full flex-shrink-0"
+          style={{ background: mktBadge.bg, color: mktBadge.color }}>
+          {mktBadge.label}
+        </span>
+        <span className="text-[13px] font-semibold text-[#191F28] truncate">{item.name}</span>
+        <span className="text-[11px] text-[#B0B8C1] font-mono flex-shrink-0">{item.symbol}</span>
+      </div>
+      <div className="text-right flex-shrink-0 ml-3">
+        <div className="text-[12px] font-bold tabular-nums font-mono" style={{ color }}>
+          {isUp ? '▲' : isDown ? '▼' : '—'}{Math.abs(pct).toFixed(2)}%
+        </div>
+        <div className="text-[10px] text-[#8B95A1] font-mono tabular-nums">{price}</div>
+      </div>
+    </button>
+  );
+}
+
+export default function NewsSidePanel({ news, allData, krwRate, onClose, onRelatedClick }) {
+  const { krStocks = [], usStocks = [], coins = [] } = allData || {};
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    const onKey = e => { if (e.key === 'Escape') onClose?.(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // 관련 종목 매칭 — 뉴스 제목+본문으로 종목명 스캔
+  const relatedItems = useMemo(() => {
+    if (!news) return [];
+    const text = `${news.title || ''} ${news.description || ''} ${news.summary || ''}`;
+    const all = [
+      ...krStocks.map(s => ({ ...s, _market: 'KR' })),
+      ...usStocks.map(s => ({ ...s, _market: 'US' })),
+      ...coins.map(c => ({ ...c, _market: 'COIN' })),
+    ];
+    return all.filter(item => {
+      const keywords = buildStockKeywords(item.symbol, item.name,
+        item._market === 'KR' ? 'KR' : item._market === 'COIN' ? 'COIN' : 'US');
+      return keywords.length > 0 && matchesKeywords(text, keywords);
+    }).slice(0, 8);
+  }, [news, krStocks, usStocks, coins]);
+
+  if (!news) return null;
+
+  const cat = CAT_COLOR[news.category] || { bg: '#F2F4F6', color: '#6B7684', label: 'NEWS' };
+  // description에서 HTML 태그 제거
+  const summary = (news.description || news.summary || '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .trim()
+    .slice(0, 300);
+
+  return (
+    <>
+      {/* 딤 오버레이 */}
+      <div
+        className="fixed inset-0 bg-black/30 z-40"
+        onClick={onClose}
+      />
+
+      {/* 슬라이드 패널 */}
+      <div
+        className="fixed top-0 right-0 h-full w-full sm:w-[420px] bg-white z-50 shadow-2xl flex flex-col"
+        style={{ animation: 'slideInRight 0.25s ease-out' }}
+      >
+        {/* 헤더 */}
+        <div className="flex-shrink-0 flex items-center justify-between px-4 py-4 border-b border-[#F2F4F6]">
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] font-bold px-2 py-0.5 rounded"
+              style={{ background: cat.bg, color: cat.color }}>
+              {cat.label}
+            </span>
+            {news.source && (
+              <span className="text-[11px] text-[#8B95A1]">{news.source}</span>
+            )}
+            {news.timeAgo && (
+              <span className="text-[11px] text-[#C9CDD2]">{news.timeAgo}</span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#F2F4F6] text-[#6B7684] transition-colors text-[18px]"
+          >×</button>
+        </div>
+
+        {/* 스크롤 영역 */}
+        <div className="flex-1 overflow-y-auto">
+          {/* 제목 */}
+          <div className="px-4 pt-4 pb-3">
+            <h2 className="text-[16px] font-bold text-[#191F28] leading-snug">
+              {news.title}
+            </h2>
+          </div>
+
+          {/* 요약 */}
+          {summary && (
+            <div className="px-4 pb-4">
+              <div className="flex items-center gap-1.5 mb-2">
+                <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-[#F2F4F6] text-[#6B7684]">
+                  요약
+                </span>
+              </div>
+              <p className="text-[13px] text-[#4E5968] leading-relaxed">
+                {summary}{summary.length >= 300 ? '…' : ''}
+              </p>
+            </div>
+          )}
+
+          {/* 관련 종목 */}
+          <div className="border-t border-[#F2F4F6]">
+            <div className="flex items-center gap-2 px-4 py-3">
+              <span className="text-[12px] font-bold text-[#191F28]">관련 종목</span>
+              {relatedItems.length > 0 && (
+                <span className="text-[11px] text-[#B0B8C1]">{relatedItems.length}개</span>
+              )}
+            </div>
+            {relatedItems.length === 0 ? (
+              <div className="px-4 pb-4 text-[12px] text-[#B0B8C1]">
+                매칭된 종목이 없습니다
+              </div>
+            ) : (
+              <div className="divide-y divide-[#F2F4F6]">
+                {relatedItems.map(item => (
+                  <RelatedRow
+                    key={item.id || item.symbol}
+                    item={item}
+                    krwRate={krwRate}
+                    onItemClick={(item) => {
+                      onClose?.();
+                      setTimeout(() => onRelatedClick?.(item), 250);
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 하단: 원문 보기 */}
+        {news.link && (
+          <div className="flex-shrink-0 px-4 py-4 border-t border-[#F2F4F6]">
+            <a
+              href={news.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-1.5 w-full py-2.5 rounded-xl border border-[#E5E8EB] text-[13px] font-medium text-[#4E5968] hover:bg-[#F7F8FA] transition-colors"
+            >
+              원문 보기
+              <span className="text-[11px]">↗</span>
+            </a>
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes slideInRight {
+          from { transform: translateX(100%); }
+          to   { transform: translateX(0); }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -65,7 +65,7 @@ export default function HomeDashboard({
       <MarketPulseWidget indices={indices} krwRate={krwRate} />
 
       {/* ─── WIDGET 2: 관심종목 ────────────────────────────── */}
-      <WatchlistWidget watchedItems={watchedItems} toggle={toggle} onItemClick={onItemClick} />
+      <WatchlistWidget watchedItems={watchedItems} toggle={toggle} onItemClick={onItemClick} krwRate={krwRate} />
 
       {/* ─── WIDGET 5: Signal (이유 있는 움직임 + 선행신호) ── */}
       {hasData && (

--- a/src/components/home/widgets/WatchlistWidget.jsx
+++ b/src/components/home/widgets/WatchlistWidget.jsx
@@ -1,7 +1,7 @@
 // 관심종목 위젯
 import { getPct, fmt } from '../utils';
 
-function WatchRow({ item, krwRate, onItemClick }) {
+function WatchRow({ item, krwRate, onItemClick, onToggle }) {
   const pct    = getPct(item);
   const isUp   = pct > 0;
   const isDown = pct < 0;
@@ -22,10 +22,9 @@ function WatchRow({ item, krwRate, onItemClick }) {
 
   return (
     <div
-      onClick={() => onItemClick?.(item)}
-      className="flex items-center justify-between px-4 py-2.5 hover:bg-[#F7F8FA] cursor-pointer transition-colors rounded-xl"
+      className="flex items-center justify-between px-4 py-2.5 hover:bg-[#F7F8FA] transition-colors rounded-xl"
     >
-      <div className="flex items-center gap-2 min-w-0">
+      <div className="flex items-center gap-2 min-w-0 flex-1 cursor-pointer" onClick={() => onItemClick?.(item)}>
         <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full flex-shrink-0"
           style={{ background: mktBadge.bg, color: mktBadge.color }}>
           {mktBadge.label}
@@ -38,11 +37,18 @@ function WatchRow({ item, krwRate, onItemClick }) {
         </div>
         <div className="text-[10px] text-[#8B95A1] tabular-nums font-mono">{price}</div>
       </div>
+      <button
+        onClick={(e) => { e.stopPropagation(); onToggle?.(item.id || item.symbol); }}
+        className="ml-2 flex-shrink-0 w-7 h-7 flex items-center justify-center rounded-lg hover:bg-[#FFF0F0] transition-colors text-[14px]"
+        title="관심종목 제거"
+      >
+        ★
+      </button>
     </div>
   );
 }
 
-export default function WatchlistWidget({ watchedItems, toggle, onItemClick }) {
+export default function WatchlistWidget({ watchedItems, toggle, onItemClick, krwRate = 1466 }) {
   if (!watchedItems.length) {
     return (
       <div className="bg-white rounded-2xl p-4 border border-[#F2F4F6] shadow-sm">
@@ -64,7 +70,7 @@ export default function WatchlistWidget({ watchedItems, toggle, onItemClick }) {
       </div>
       <div className="py-1 max-h-[280px] overflow-y-auto">
         {watchedItems.map(item => (
-          <WatchRow key={item.id || item.symbol} item={item} onItemClick={onItemClick} />
+          <WatchRow key={item.id || item.symbol} item={item} krwRate={krwRate} onItemClick={onItemClick} onToggle={toggle} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 뉴스 클릭 시 외부 링크 이동 대신 슬라이드 패널로 요약 + 관련종목 표시 (ChartSidePanel과 동일 패턴)
- 관심종목 위젯의 ★ 버튼 실제 동작 (krwRate/onToggle prop 전달 누락 수정)

## 변경 내용
- `NewsSidePanel.jsx` (신규): 뉴스 요약, HTML태그 제거, 관련종목 매칭(buildStockKeywords), 원문보기 링크
- `BreakingNewsPanel`: onNewsClick/onItemClick 분리 — 뉴스→NewsSidePanel, 고래이벤트→ChartSidePanel
- `WatchlistWidget`: WatchRow에 krwRate + onToggle 전달
- `App.jsx`: selectedNews state 추가, NewsSidePanel 렌더링

🤖 Generated with [Claude Code](https://claude.com/claude-code)