### PR TITLE
feat: KRX ETF 전체 목록 연동

### DIFF
--- a/api/krx-etf.js
+++ b/api/krx-etf.js
@@ -1,0 +1,89 @@
+// api/krx-etf.js — KRX Open API로 국내 ETF 전체 목록 조회
+// GET /api/krx-etf
+// 전일 종가 기준 (실시간 아님), GlobalSearch 종목 확보용
+// 거래일 기준 최근 5일 중 데이터 있는 날 자동 선택
+
+const KRX_BASE  = 'https://data-dbg.krx.co.kr/svc/apis';
+const AUTH_KEY  = process.env.KRX_API_KEY;
+
+// YYYYMMDD 형식 날짜 — offset 일 이전
+function dateStr(offsetDays = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() - offsetDays);
+  // 주말 건너뛰기
+  while (d.getDay() === 0 || d.getDay() === 6) d.setDate(d.getDate() - 1);
+  return d.toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+async function fetchEtfForDate(basDd) {
+  const res = await fetch(`${KRX_BASE}/etp/etf_bydd_trd`, {
+    method:  'POST',
+    headers: {
+      'AUTH_KEY':    AUTH_KEY.trim(),
+      'Content-Type': 'application/json',
+    },
+    body:   JSON.stringify({ basDd }),
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!res.ok) throw new Error(`KRX ${res.status}`);
+  const data = await res.json();
+  const list = data?.OutBlock_1 ?? [];
+  return list;
+}
+
+// 숫자 문자열 정제 — 콤마/공백 제거
+function num(s) {
+  if (!s) return 0;
+  return parseFloat(String(s).replace(/,/g, '').trim()) || 0;
+}
+
+export default async function handler(req) {
+  if (!AUTH_KEY) {
+    return Response.json({ error: 'KRX_API_KEY not set', etfs: [] }, { status: 500 });
+  }
+
+  // 최근 5 거래일 중 데이터 있는 날 사용
+  let list = [];
+  for (let i = 1; i <= 7; i++) {
+    try {
+      const basDd = dateStr(i);
+      const rows = await fetchEtfForDate(basDd);
+      if (rows.length > 0) { list = rows; break; }
+    } catch { /* 다음 날짜 시도 */ }
+  }
+
+  if (!list.length) {
+    return Response.json({ etfs: [] }, {
+      headers: { 'Cache-Control': 'public, s-maxage=3600' },
+    });
+  }
+
+  // KRX 응답 → 프론트 ETF_DATA 포맷으로 변환
+  const etfs = list.map(r => {
+    const price     = num(r.TDD_CLSPRC);
+    const prevClose = price - num(r.CMPPREVDD_PRC);
+    const change    = num(r.CMPPREVDD_PRC);
+    const changePct = prevClose > 0
+      ? parseFloat(((change / prevClose) * 100).toFixed(2))
+      : 0;
+    return {
+      symbol:    (r.ISU_CD  || r.ISU_SRT_CD || '').trim(),
+      name:      (r.ISU_NM  || r.ISU_ABBRV  || '').trim(),
+      market:    'kr',
+      sector:    'ETF',
+      category:  'ETF',
+      price:     parseFloat(price.toFixed(0)),
+      change:    parseFloat(change.toFixed(0)),
+      changePct,
+      volume:    num(r.ACC_TRDVOL),
+      aum:       num(r.MKTCAP),
+    };
+  }).filter(e => e.symbol && e.name && e.price > 0);
+
+  return Response.json({ etfs }, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=21600, stale-while-revalidate=3600', // 6시간 캐싱
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import { ETF_DATA } from './data/mock';
 import { fetchKoreanStocksBatch, fetchEtfPricesBatch } from './api/stocks';
 import { requestNotificationPermission, getNotificationPermission, setAlertWatchlistIds } from './utils/priceAlert';
 import { useWatchlist } from './hooks/useWatchlist';
+import { useKrxEtf } from './hooks/useKrxEtf';
 import { useKisWebSocket } from './hooks/useKisWebSocket';
 import { usePrices } from './hooks/usePrices';
 import { useCoins } from './hooks/useCoins';
@@ -36,6 +37,7 @@ export default function App() {
   // krSymbols 동기화
   useEffect(() => { krSymbolsRef.current = krSymbols; }, [krSymbols, krSymbolsRef]);
 
+  const { data: krxEtfs = [] } = useKrxEtf();
   const [activeTab, setActiveTab]       = useState('home');
   const [etfs, setEtfs]                 = useState(ETF_DATA);
   const [lastUpdated, setLastUpdated]   = useState(null);
@@ -124,8 +126,16 @@ export default function App() {
     return () => document.removeEventListener('keydown', onKey);
   }, []);
 
+  // KRX ETF 병합 — 기존 ETF_DATA + KRX 신규 ETF (중복 symbol 제거)
+  const mergedEtfs = useMemo(() => {
+    if (!krxEtfs.length) return etfs;
+    const existingSymbols = new Set(etfs.map(e => e.symbol));
+    const newEtfs = krxEtfs.filter(e => !existingSymbols.has(e.symbol));
+    return [...etfs, ...newEtfs];
+  }, [etfs, krxEtfs]);
+
   // 탭별 데이터
-  const etfItems       = useMemo(() => etfs.map(e => ({ ...e, marketCap: e.aum })), [etfs]);
+  const etfItems       = useMemo(() => mergedEtfs.map(e => ({ ...e, marketCap: e.aum })), [mergedEtfs]);
   const activeCoinData = activeTab === 'coin' ? coins : undefined;
   const tabItems       = useMemo(() => {
     switch (activeTab) {
@@ -138,7 +148,7 @@ export default function App() {
     }
   }, [activeTab, krStocks, usStocks, activeCoinData, etfItems]);
   const allStocks = useMemo(() => [...krStocks, ...usStocks], [krStocks, usStocks]);
-  const allData   = useMemo(() => ({ krStocks, usStocks, coins, etfs }), [krStocks, usStocks, coins, etfs]);
+  const allData   = useMemo(() => ({ krStocks, usStocks, coins, etfs: mergedEtfs }), [krStocks, usStocks, coins, mergedEtfs]);
 
   return (
     <div className="min-h-screen bg-[#F8F9FA]">
@@ -171,7 +181,7 @@ export default function App() {
           {activeTab === 'home' ? (
             <HomeDashboard
               indices={indices} krStocks={krStocks} usStocks={usStocks}
-              coins={coins} etfs={etfs} krwRate={krwRate} onItemClick={setSelectedItem}
+              coins={coins} etfs={mergedEtfs} krwRate={krwRate} onItemClick={setSelectedItem}
             />
           ) : activeTab === 'news' ? (
             <div className="lg:hidden h-[calc(100vh-112px)]">

--- a/src/hooks/useKrxEtf.js
+++ b/src/hooks/useKrxEtf.js
@@ -1,0 +1,18 @@
+// KRX ETF 전체 목록 — 앱 로드 시 1회 fetch, 6시간 캐싱
+import { useQuery } from '@tanstack/react-query';
+
+async function fetchKrxEtf() {
+  const res = await fetch('/api/krx-etf');
+  if (!res.ok) throw new Error(`krx-etf ${res.status}`);
+  const { etfs = [] } = await res.json();
+  return etfs;
+}
+
+export function useKrxEtf() {
+  return useQuery({
+    queryKey:  ['krx-etf'],
+    queryFn:   fetchKrxEtf,
+    staleTime: 6 * 60 * 60 * 1000, // 6시간
+    retry:     1,
+  });
+}


### PR DESCRIPTION
## Summary
- KRX Open API로 국내 ETF 전체 목록 확보 (약 800개)
- GlobalSearch에서 KRX 전종목 ETF 검색 가능
- 기존 ETF_DATA와 병합 (중복 제거), 6시간 캐싱

🤖 Generated with [Claude Code](https://claude.com/claude-code)