### PR TITLE
fix: UX 개선 일괄 수정 (10개 이슈)

### DIFF
--- a/api/news-summary.js
+++ b/api/news-summary.js
@@ -1,5 +1,5 @@
 // api/news-summary.js — Gemini 기반 뉴스 요약 Vercel Edge Function
-// GET /api/news-summary?url=<기사URL>&fallback=<RSS_description>
+// GET /api/news-summary?url=<기사URL>&title=<제목>&fallback=<RSS_description>
 export const config = { runtime: 'edge' };
 
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
@@ -52,6 +52,7 @@ async function summarize(text) {
 export default async function handler(req) {
   const { searchParams } = new URL(req.url);
   const url      = searchParams.get('url');
+  const title    = searchParams.get('title') || '';
   const fallback = searchParams.get('fallback') || '';
 
   if (!url) {
@@ -67,13 +68,18 @@ export default async function handler(req) {
   }
 
   try {
-    // 기사 크롤 시도 → 실패 시 RSS fallback 텍스트 사용
-    let text = fallback;
+    // 기사 크롤 시도 → 실패 시 제목+RSS description 조합
+    let articleText = '';
     try {
-      text = await fetchArticleText(url);
-    } catch { /* 크롤 실패 — fallback 유지 */ }
+      articleText = await fetchArticleText(url);
+    } catch { /* 크롤 실패 */ }
 
-    if (!text || text.length < 30) {
+    // 크롤 성공 시 기사 본문, 실패 시 제목+description 조합
+    const text = articleText.length > 200
+      ? articleText
+      : [title, fallback].filter(Boolean).join('\n\n');
+
+    if (!text || text.length < 20) {
       return new Response(JSON.stringify({ summary: null }), {
         headers: { 'Content-Type': 'application/json' },
       });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,7 +181,8 @@ export default function App() {
           {activeTab === 'home' ? (
             <HomeDashboard
               indices={indices} krStocks={krStocks} usStocks={usStocks}
-              coins={coins} etfs={mergedEtfs} krwRate={krwRate} onItemClick={setSelectedItem}
+              coins={coins} etfs={mergedEtfs} krwRate={krwRate}
+              onItemClick={setSelectedItem} onNewsClick={setSelectedNews}
             />
           ) : activeTab === 'news' ? (
             <div className="lg:hidden h-[calc(100vh-112px)]">

--- a/src/api/chart.js
+++ b/src/api/chart.js
@@ -172,21 +172,25 @@ export async function fetchCandles(item, periodKey = '5분') {
     }
   }
 
-  // 국내 주식: 일/주/월봉은 한투 API 우선 (Yahoo .KS 404 대체)
+  // 국내 주식: 일/주/월봉은 한투 API 우선 → Yahoo .KS → Yahoo .KQ (코스닥)
   // 분봉/시봉(intraday)은 Yahoo fallback (한투 분봉 API는 별도 구현 필요)
   if (item.market === 'kr') {
     if (!isIntraday) {
-      // 일봉=D, 주봉=W, 월봉=M 매핑
       const periodMap = { '1d': 'D', '1wk': 'W', '1mo': 'M' };
       const periodCode = periodMap[interval] ?? 'D';
       try {
         return await fetchHantooCandles(item.symbol, periodCode);
-      } catch {
-        // 한투 실패 시 Yahoo fallback
+      } catch (err) {
+        console.warn(`[chart] 한투 실패 ${item.symbol}:`, err.message);
       }
     }
-    const sym = `${item.symbol}.KS`;
-    return fetchStockCandles(sym, range, interval);
+    // Yahoo fallback: .KS (코스피) 시도 → .KQ (코스닥) 시도
+    try {
+      return await fetchStockCandles(`${item.symbol}.KS`, range, interval);
+    } catch {
+      console.warn(`[chart] Yahoo .KS 실패 ${item.symbol}, .KQ 시도`);
+    }
+    return fetchStockCandles(`${item.symbol}.KQ`, range, interval);
   }
 
   // 미국 주식: Yahoo Finance 그대로

--- a/src/api/whale.js
+++ b/src/api/whale.js
@@ -252,8 +252,8 @@ export function unsubscribeUpbitWhaleTrades() {
 }
 
 // ─── Layer 1b: 빗썸 WebSocket — 거래소 대량 체결 ─────────────────────────────
-const BITHUMB_THRESHOLD_KRW = 20_000_000; // 2천만 원
-const BITHUMB_HIGH_KRW      = 200_000_000; // 2억 원
+const BITHUMB_THRESHOLD_KRW = 100_000_000; // 1억 원 (고래 기준)
+const BITHUMB_HIGH_KRW      = 500_000_000; // 5억 원 (기관급)
 
 let bithumbWs        = null;
 let bithumbHandler   = null;

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -26,7 +26,10 @@ function getPrice(item, krwRate) {
 const MARKET_LABEL = { kr: '국내', us: '미장', coin: '코인', etf: 'ETF' };
 const MARKET_COLOR = { kr: '#F04452', us: '#3182F6', coin: '#FF9500', etf: '#8B5CF6' };
 
+import { useWatchlist } from '../hooks/useWatchlist';
+
 export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [], etfs = [], krwRate = 1466, onSelect, onClose }) {
+  const { toggle, isWatched } = useWatchlist();
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [naverItems, setNaverItems] = useState([]);
@@ -246,7 +249,7 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
                   </div>
 
                   {/* 가격 + 등락률 */}
-                  <div className="text-right flex-shrink-0 pr-4">
+                  <div className="text-right flex-shrink-0">
                     <div className="text-[13px] font-semibold text-[#191F28] tabular-nums font-mono">
                       {getPrice(item, krwRate)}
                     </div>
@@ -254,6 +257,17 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
                       {isUp ? '▲' : isDown ? '▼' : ''}{Math.abs(pct).toFixed(2)}%
                     </div>
                   </div>
+
+                  {/* 관심종목 ★ */}
+                  <button
+                    onClick={(e) => { e.stopPropagation(); toggle(item.id || item.symbol); }}
+                    className={`flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg transition-colors text-[16px] mr-2 ${
+                      isWatched(item.id || item.symbol) ? 'text-[#FF9500] hover:bg-[#FFF4E6]' : 'text-[#D5D8DC] hover:bg-[#F2F4F6]'
+                    }`}
+                    title={isWatched(item.id || item.symbol) ? '관심종목 해제' : '관심종목 추가'}
+                  >
+                    {isWatched(item.id || item.symbol) ? '★' : '☆'}
+                  </button>
                 </button>
               );
             })

--- a/src/components/NewsSidePanel.jsx
+++ b/src/components/NewsSidePanel.jsx
@@ -77,6 +77,7 @@ export default function NewsSidePanel({ news, allData, krwRate, onClose, onRelat
     const rssDesc = (news.description || news.summary || '')
       .replace(/<[^>]+>/g, '').trim().slice(0, 500);
     const params = new URLSearchParams({ url: news.link });
+    if (news.title) params.set('title', news.title);
     if (rssDesc) params.set('fallback', rssDesc);
     fetch(`/api/news-summary?${params}`)
       .then(r => r.json())

--- a/src/components/home/EventTicker.jsx
+++ b/src/components/home/EventTicker.jsx
@@ -1,0 +1,150 @@
+// 경제 이벤트 티커 — 다가오는 이벤트 롤링 표시
+// 클릭 시 전체 캘린더 모달 오픈
+import { useState, useEffect, useMemo } from 'react';
+
+// 2026년 주요 경제 이벤트 (향후 API 전환 가능)
+const EVENTS_2026 = [
+  { date: '2026-03-18', type: 'FOMC', label: 'FOMC 금리 결정', importance: 'high' },
+  { date: '2026-03-27', type: 'PCE',  label: 'PCE 물가지수', importance: 'medium' },
+  { date: '2026-04-03', type: 'NFP',  label: '비농업 고용지표', importance: 'high' },
+  { date: '2026-04-10', type: 'CPI',  label: 'CPI 발표 (3월)', importance: 'high' },
+  { date: '2026-04-16', type: '금통위', label: '한국은행 기준금리 결정', importance: 'high' },
+  { date: '2026-04-29', type: 'FOMC', label: 'FOMC 금리 결정', importance: 'high' },
+  { date: '2026-04-29', type: 'GDP',  label: 'GDP 1차 발표 (Q1)', importance: 'medium' },
+  { date: '2026-04-30', type: 'PCE',  label: 'PCE 물가지수', importance: 'medium' },
+  { date: '2026-05-01', type: 'NFP',  label: '비농업 고용지표', importance: 'high' },
+  { date: '2026-05-13', type: 'CPI',  label: 'CPI 발표 (4월)', importance: 'high' },
+  { date: '2026-05-28', type: '금통위', label: '한국은행 기준금리 결정', importance: 'high' },
+  { date: '2026-05-29', type: 'PCE',  label: 'PCE 물가지수', importance: 'medium' },
+  { date: '2026-06-05', type: 'NFP',  label: '비농업 고용지표', importance: 'high' },
+  { date: '2026-06-10', type: 'FOMC', label: 'FOMC 금리 결정', importance: 'high' },
+  { date: '2026-06-10', type: 'CPI',  label: 'CPI 발표 (5월)', importance: 'high' },
+  { date: '2026-07-02', type: 'NFP',  label: '비농업 고용지표', importance: 'high' },
+  { date: '2026-07-15', type: 'CPI',  label: 'CPI 발표 (6월)', importance: 'high' },
+  { date: '2026-07-16', type: '금통위', label: '한국은행 기준금리 결정', importance: 'high' },
+  { date: '2026-07-29', type: 'FOMC', label: 'FOMC 금리 결정', importance: 'high' },
+  { date: '2026-07-30', type: 'GDP',  label: 'GDP 1차 발표 (Q2)', importance: 'medium' },
+  { date: '2026-08-12', type: 'CPI',  label: 'CPI 발표 (7월)', importance: 'high' },
+  { date: '2026-08-27', type: '금통위', label: '한국은행 기준금리 결정', importance: 'high' },
+  { date: '2026-09-10', type: 'CPI',  label: 'CPI 발표 (8월)', importance: 'high' },
+  { date: '2026-09-16', type: 'FOMC', label: 'FOMC 금리 결정', importance: 'high' },
+  { date: '2026-10-14', type: 'CPI',  label: 'CPI 발표 (9월)', importance: 'high' },
+  { date: '2026-10-28', type: 'FOMC', label: 'FOMC 금리 결정', importance: 'high' },
+  { date: '2026-11-11', type: 'CPI',  label: 'CPI 발표 (10월)', importance: 'high' },
+  { date: '2026-12-09', type: 'FOMC', label: 'FOMC 금리 결정', importance: 'high' },
+  { date: '2026-12-09', type: 'CPI',  label: 'CPI 발표 (11월)', importance: 'high' },
+];
+
+const TYPE_CONFIG = {
+  FOMC:  { color: '#F04452', bg: '#FFF0F0', emoji: '🏦' },
+  CPI:   { color: '#3182F6', bg: '#EDF4FF', emoji: '📊' },
+  NFP:   { color: '#FF9500', bg: '#FFF4E6', emoji: '👷' },
+  PCE:   { color: '#8B5CF6', bg: '#F5F0FF', emoji: '💳' },
+  GDP:   { color: '#2AC769', bg: '#F0FFF6', emoji: '📈' },
+  금통위: { color: '#F04452', bg: '#FFF0F0', emoji: '🏛' },
+};
+
+function dday(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00+09:00');
+  const now = new Date();
+  const diff = Math.ceil((d - now) / (24 * 60 * 60 * 1000));
+  if (diff === 0) return { text: 'D-DAY', urgent: true };
+  if (diff === 1) return { text: 'D-1', urgent: true };
+  if (diff <= 3) return { text: `D-${diff}`, urgent: true };
+  if (diff <= 7) return { text: `D-${diff}`, urgent: false };
+  return { text: `D-${diff}`, urgent: false };
+}
+
+function FullCalendarModal({ events, onClose }) {
+  useEffect(() => {
+    const onKey = e => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/30 z-40" onClick={onClose} />
+      <div className="fixed top-[10vh] left-1/2 -translate-x-1/2 w-full max-w-[480px] bg-white rounded-2xl shadow-2xl z-50 overflow-hidden max-h-[80vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
+          <span className="text-[14px] font-bold text-[#191F28]">경제 이벤트 캘린더</span>
+          <button onClick={onClose} className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#F2F4F6] text-[#6B7684] text-[18px]">×</button>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {events.map((ev, i) => {
+            const cfg = TYPE_CONFIG[ev.type] || { color: '#8B95A1', bg: '#F2F4F6', emoji: '📅' };
+            const dd = dday(ev.date);
+            const d = new Date(ev.date);
+            const dateLabel = `${d.getMonth()+1}/${d.getDate()} (${['일','월','화','수','목','금','토'][d.getDay()]})`;
+            return (
+              <div key={`${ev.date}-${ev.type}-${i}`}
+                className={`flex items-center gap-3 px-4 py-3 border-b border-[#F2F4F6] last:border-0 ${dd.urgent ? 'bg-[#FFF8F0]' : ''}`}>
+                <span className="text-[16px] flex-shrink-0">{cfg.emoji}</span>
+                <div className="flex-1 min-w-0">
+                  <span className="text-[10px] font-bold px-1.5 py-0.5 rounded mr-1.5"
+                    style={{ background: cfg.bg, color: cfg.color }}>{ev.type}</span>
+                  <span className="text-[13px] font-medium text-[#191F28]">{ev.label}</span>
+                  <div className="text-[11px] text-[#8B95A1] mt-0.5">{dateLabel}</div>
+                </div>
+                <span className={`text-[12px] font-bold tabular-nums flex-shrink-0 ${dd.urgent ? 'text-[#F04452]' : 'text-[#8B95A1]'}`}>
+                  {dd.text}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default function EventTicker() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  // 향후 30일 이내 이벤트
+  const upcoming = useMemo(() => {
+    const now = new Date();
+    const limit = new Date(now.getTime() + 30 * 86400000);
+    return EVENTS_2026
+      .filter(e => { const d = new Date(e.date); return d >= now && d <= limit; })
+      .sort((a, b) => new Date(a.date) - new Date(b.date));
+  }, []);
+
+  // 3초마다 롤링
+  useEffect(() => {
+    if (upcoming.length <= 1) return;
+    const id = setInterval(() => setActiveIdx(i => (i + 1) % upcoming.length), 3000);
+    return () => clearInterval(id);
+  }, [upcoming.length]);
+
+  if (!upcoming.length) return null;
+
+  const ev = upcoming[activeIdx % upcoming.length];
+  const cfg = TYPE_CONFIG[ev.type] || { color: '#8B95A1', bg: '#F2F4F6', emoji: '📅' };
+  const dd = dday(ev.date);
+
+  return (
+    <>
+      <button
+        onClick={() => setModalOpen(true)}
+        className="w-full flex items-center gap-2.5 px-4 py-2.5 bg-white rounded-xl border border-[#F2F4F6] shadow-sm hover:bg-[#FAFBFC] transition-colors"
+      >
+        <span className="text-[14px] flex-shrink-0">{cfg.emoji}</span>
+        <span className="text-[10px] font-bold px-1.5 py-0.5 rounded flex-shrink-0"
+          style={{ background: cfg.bg, color: cfg.color }}>{ev.type}</span>
+        <span className="text-[12px] font-medium text-[#191F28] truncate">{ev.label}</span>
+        <span className={`text-[11px] font-bold tabular-nums flex-shrink-0 ml-auto ${dd.urgent ? 'text-[#F04452]' : 'text-[#8B95A1]'}`}>
+          {dd.text}
+        </span>
+        {upcoming.length > 1 && (
+          <span className="text-[10px] text-[#C9CDD2] flex-shrink-0">
+            +{upcoming.length - 1}
+          </span>
+        )}
+      </button>
+
+      {modalOpen && <FullCalendarModal events={upcoming} onClose={() => setModalOpen(false)} />}
+    </>
+  );
+}

--- a/src/components/home/SignalSection.jsx
+++ b/src/components/home/SignalSection.jsx
@@ -27,7 +27,7 @@ function SignalCard({ mover, news, krwRate, onItemClick }) {
   // 시그널 강도 (이유 근거)
   const signalReason = news
     ? news.title.length > 60 ? news.title.slice(0, 58) + '…' : news.title
-    : `${Math.abs(pct).toFixed(1)}% ${isUp ? '상승' : '하락'} 중 — 이유 분석 중`;
+    : `${Math.abs(pct).toFixed(1)}% ${isUp ? '상승' : '하락'} 중`;
 
   const mktBadge = isCoin ? { label: 'COIN', bg: '#FFF4E6', color: '#FF9500' }
     : mover._market === 'KR' || mover.market === 'kr'
@@ -104,7 +104,8 @@ export default function SignalSection({ allItems, recentNews, krwRate, onItemCli
     for (const mover of movers) {
       if (results.length >= 3) break;
       const newsMatch = findRelatedNews(mover, recentNews);
-      results.push({ mover, news: newsMatch || null });
+      // 뉴스 매칭된 종목만 표시 — 매칭 없으면 카드 생성하지 않음
+      if (newsMatch) results.push({ mover, news: newsMatch });
     }
 
     // 뉴스 있는 시그널 우선 정렬

--- a/src/components/home/TopNewsSection.jsx
+++ b/src/components/home/TopNewsSection.jsx
@@ -8,7 +8,7 @@ const CAT_BADGE = {
   kr:   { bg: '#FFF0F0', color: '#F04452', label: '국내' },
 };
 
-export default function TopNewsSection({ allNews = [] }) {
+export default function TopNewsSection({ allNews = [], onNewsClick }) {
   // 24시간 이내 뉴스 중 상위 5건
   const topNews = useMemo(() => {
     const cutoff = 24 * 60 * 60 * 1000;
@@ -39,12 +39,10 @@ export default function TopNewsSection({ allNews = [] }) {
         const isBreaking = item.pubDate && (Date.now() - new Date(item.pubDate).getTime()) < 3600000;
 
         return (
-          <a
+          <div
             key={item.id || i}
-            href={item.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-start gap-3 px-4 py-3 border-b border-[#F2F4F6] last:border-0 hover:bg-[#FAFBFC] transition-colors"
+            onClick={() => onNewsClick?.(item)}
+            className="flex items-start gap-3 px-4 py-3 border-b border-[#F2F4F6] last:border-0 hover:bg-[#FAFBFC] transition-colors cursor-pointer"
           >
             {/* 번호 */}
             <span className="text-[13px] font-bold text-[#C9CDD2] tabular-nums mt-0.5 flex-shrink-0 w-4">
@@ -80,7 +78,7 @@ export default function TopNewsSection({ allNews = [] }) {
                 {item.title}
               </p>
             </div>
-          </a>
+          </div>
         );
       })}
     </div>

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -10,11 +10,12 @@ import NewsFeedWidget from './widgets/NewsFeedWidget';
 import SignalWidget from './widgets/SignalWidget';
 import MarketInvestorSection from './MarketInvestorSection';
 import EventCalendar from './EventCalendar';
+import EventTicker from './EventTicker';
 import CoinListingSection from './CoinListingSection';
 
 export default function HomeDashboard({
   indices = [], krStocks = [], usStocks = [], coins = [], etfs = [],
-  krwRate = 1466, onItemClick,
+  krwRate = 1466, onItemClick, onNewsClick,
 }) {
   const { data: allNews = [] } = useAllNewsQuery();
   const { watchlist, toggle, isWatched } = useWatchlist();
@@ -64,6 +65,9 @@ export default function HomeDashboard({
       {/* ─── WIDGET 1: Market Pulse ───────────────────────── */}
       <MarketPulseWidget indices={indices} krwRate={krwRate} />
 
+      {/* ─── 경제 이벤트 티커 (펄스↔관심종목 사이) ─────────── */}
+      <EventTicker />
+
       {/* ─── WIDGET 2: 관심종목 ────────────────────────────── */}
       <WatchlistWidget watchedItems={watchedItems} toggle={toggle} onItemClick={onItemClick} krwRate={krwRate} />
 
@@ -90,7 +94,7 @@ export default function HomeDashboard({
       />
 
       {/* ─── WIDGET 4: 뉴스 피드 ──────────────────────────── */}
-      <NewsFeedWidget allNews={allNews} />
+      <NewsFeedWidget allNews={allNews} onNewsClick={onNewsClick} />
 
       {/* ─── 코인 거래소 공지 ─────────────────────────────── */}
       <CoinListingSection />

--- a/src/components/home/widgets/NewsFeedWidget.jsx
+++ b/src/components/home/widgets/NewsFeedWidget.jsx
@@ -1,6 +1,6 @@
 // 뉴스 피드 위젯
 import TopNewsSection from '../TopNewsSection';
 
-export default function NewsFeedWidget({ allNews }) {
-  return <TopNewsSection allNews={allNews} />;
+export default function NewsFeedWidget({ allNews, onNewsClick }) {
+  return <TopNewsSection allNews={allNews} onNewsClick={onNewsClick} />;
 }

--- a/src/components/home/widgets/SignalWidget.jsx
+++ b/src/components/home/widgets/SignalWidget.jsx
@@ -1,12 +1,8 @@
-// 시그널 위젯 — SignalSection + EarlySignalSection 통합
+// 시그널 위젯 — 뉴스 매칭된 급등/급락 종목만 표시
 import SignalSection from '../SignalSection';
-import EarlySignalSection from '../EarlySignalSection';
 
 export default function SignalWidget({ allItems, recentNews, krwRate, onItemClick }) {
   return (
-    <div className="space-y-3">
-      <SignalSection allItems={allItems} recentNews={recentNews} krwRate={krwRate} onItemClick={onItemClick} />
-      <EarlySignalSection allItems={allItems} recentNews={recentNews} krwRate={krwRate} onItemClick={onItemClick} />
-    </div>
+    <SignalSection allItems={allItems} recentNews={recentNews} krwRate={krwRate} onItemClick={onItemClick} />
   );
 }


### PR DESCRIPTION
## Summary
- Signal 카드: 뉴스 매칭 없는 항목 제거
- AI 뉴스 요약 품질 개선 (title 파라미터, fallback 강화)
- 핵심뉴스 클릭 → NewsSidePanel 슬라이드 패널
- EventTicker: 펄스↔관심종목 사이 경제 이벤트 롤링
- 차트: .KS → .KQ 코스닥 fallback 추가
- 고래알림: 빗썸 임계치 1억/5억 상향
- EarlySignalSection 제거
- GlobalSearch ★ 관심종목 토글 버튼

## Test plan
- [ ] Signal 위젯에 '이유 분석 중' 표시 없는지 확인
- [ ] 뉴스 클릭 시 슬라이드 패널 + AI 요약 표시
- [ ] EventTicker 롤링 + 모달 동작
- [ ] 펄어비스 등 코스닥 종목 차트 로딩
- [ ] GlobalSearch에서 ★ 토글 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)