### PR TITLE
fix: 뉴스 AI 요약 품질 개선

### DIFF
--- a/api/news-summary.js
+++ b/api/news-summary.js
@@ -5,42 +5,83 @@ export const config = { runtime: 'edge' };
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent';
 
-// 기사 HTML 크롤 후 텍스트 추출
-async function fetchArticleText(url) {
-  const res = await fetch(url, {
-    headers: {
-      'User-Agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-      'Accept': 'text/html',
-    },
-    signal: AbortSignal.timeout(6000),
-  });
-  if (!res.ok) throw new Error(`fetch ${res.status}`);
-  const html = await res.text();
-  return html
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-    .replace(/<[^>]+>/g, ' ')
+// HTML 엔티티 디코딩 + 공백 정리
+function cleanText(s) {
+  return s
     .replace(/&nbsp;/g, ' ')
     .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
     .replace(/\s+/g, ' ')
-    .trim()
-    .slice(0, 3000);
+    .trim();
+}
+
+// 기사 HTML 크롤 후 본문 추출 (노이즈 최소화)
+async function fetchArticleText(url) {
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      'Accept': 'text/html,application/xhtml+xml',
+      'Accept-Language': 'ko-KR,ko;q=0.9,en;q=0.8',
+    },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!res.ok) throw new Error(`fetch ${res.status}`);
+  const html = await res.text();
+
+  // og:description 추출 (메타 태그 — 대부분의 뉴스 사이트가 지원)
+  const ogMatch = html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["']/i)
+    || html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:description["']/i);
+  const ogDesc = ogMatch ? cleanText(ogMatch[1]) : '';
+
+  // script/style/nav/header/footer/aside 제거
+  const stripped = html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<nav[^>]*>[\s\S]*?<\/nav>/gi, '')
+    .replace(/<header[^>]*>[\s\S]*?<\/header>/gi, '')
+    .replace(/<footer[^>]*>[\s\S]*?<\/footer>/gi, '')
+    .replace(/<aside[^>]*>[\s\S]*?<\/aside>/gi, '');
+
+  // <article> 태그가 있으면 그 안의 텍스트만 추출
+  const articleMatch = stripped.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  if (articleMatch) {
+    const articleText = cleanText(articleMatch[1].replace(/<[^>]+>/g, ' '));
+    if (articleText.length > 200) return articleText.slice(0, 4000);
+  }
+
+  // <article> 없으면 <p> 태그 텍스트 합산 (본문 추출 핵심)
+  const pTags = stripped.match(/<p[^>]*>[^<]{20,}<\/p>/gi) || [];
+  if (pTags.length >= 2) {
+    const pText = pTags.map(p => cleanText(p.replace(/<[^>]+>/g, ' '))).join(' ');
+    if (pText.length > 200) return pText.slice(0, 4000);
+  }
+
+  // og:description이 충분하면 사용
+  if (ogDesc.length > 80) return ogDesc;
+
+  // 최종 fallback: 전체 텍스트 (노이즈 포함)
+  const fullText = cleanText(stripped.replace(/<[^>]+>/g, ' '));
+  return fullText.slice(0, 3000);
 }
 
 // Gemini로 요약
-async function summarize(text) {
+async function summarize(text, isFullArticle = false) {
+  const prompt = isFullArticle
+    ? `다음 뉴스 기사 본문을 투자자 관점에서 핵심만 3문장 이내로 한국어 요약해주세요. 구체적 수치, 종목명, 영향(상승/하락 요인)을 반드시 포함하세요. 제목을 반복하지 마세요:\n\n${text}`
+    : `다음은 뉴스 제목과 요약입니다. 이 정보만으로 투자자에게 유용한 핵심 분석을 2~3문장으로 작성해주세요. 시장 영향, 관련 섹터, 투자 시사점을 포함하세요. 제목을 그대로 반복하지 말고 새로운 인사이트를 제공하세요:\n\n${text}`;
+
   const res = await fetch(`${GEMINI_URL}?key=${GEMINI_KEY}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       contents: [{
-        parts: [{
-          text: `다음 뉴스 기사를 투자자 관점에서 핵심만 3문장 이내 한국어로 요약해주세요. 숫자와 주요 종목명을 유지해주세요:\n\n${text}`,
-        }],
+        parts: [{ text: prompt }],
       }],
-      generationConfig: { maxOutputTokens: 250, temperature: 0.2 },
+      generationConfig: { maxOutputTokens: 300, temperature: 0.3 },
     }),
     signal: AbortSignal.timeout(10000),
   });
@@ -75,7 +116,8 @@ export default async function handler(req) {
     } catch { /* 크롤 실패 */ }
 
     // 크롤 성공 시 기사 본문, 실패 시 제목+description 조합
-    const text = articleText.length > 200
+    const isFullArticle = articleText.length > 200;
+    const text = isFullArticle
       ? articleText
       : [title, fallback].filter(Boolean).join('\n\n');
 
@@ -85,7 +127,7 @@ export default async function handler(req) {
       });
     }
 
-    const summary = await summarize(text);
+    const summary = await summarize(text, isFullArticle);
     return new Response(JSON.stringify({ summary }), {
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- 크롤링 개선: Chrome UA, og:description, article/p 태그 우선 파싱
- nav/header/footer 노이즈 제거
- Gemini 프롬프트 이원화 (전문 vs 제목만)
- 짧은 텍스트일 때 제목 반복 방지 + 투자 시사점 포함 지시

## Test plan
- [ ] 뉴스 클릭 시 제목과 다른 실질적 요약 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)