### PR TITLE
fix: 지수 누락 근본 수정 + 미장 rate limit 방지 + 한투 업종지수 API

### DIFF
--- a/api/hantoo-indices.js
+++ b/api/hantoo-indices.js
@@ -1,0 +1,72 @@
+// 한투 Open API — 국내 업종지수 현재가 Vercel serverless
+// KOSPI(0001), KOSDAQ(1001) 업종 현재가 조회
+//
+// 요청: GET /api/hantoo-indices
+// 응답: { data: [ { id, value, change, changePct } ] }
+
+import { getHantooToken, HANTOO_BASE } from './_hantoo-token.js';
+
+const INDICES = [
+  { id: 'KOSPI',  code: '0001' },
+  { id: 'KOSDAQ', code: '1001' },
+];
+
+async function fetchSingleIndex(code, token) {
+  const url = new URL(`${HANTOO_BASE}/uapi/domestic-stock/v1/quotations/inquire-index-price`);
+  url.searchParams.set('FID_COND_MRKT_DIV_CODE', 'U'); // U = 업종
+  url.searchParams.set('FID_INPUT_ISCD', code);
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      Authorization:  `Bearer ${token}`,
+      appkey:         process.env.HANTOO_APP_KEY,
+      appsecret:      process.env.HANTOO_APP_SECRET,
+      tr_id:          'FHPUP02100000',
+      custtype:       'P',
+    },
+    signal: AbortSignal.timeout(6000),
+  });
+
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  if (data.rt_cd !== '0') throw new Error(data.msg1 || `rt_cd ${data.rt_cd}`);
+
+  const o = data.output;
+  const value = parseFloat(o.bstp_nmix_prpr || '0');
+  if (!value) throw new Error('지수 값 없음');
+
+  // bstp_nmix_prdy_vrss: 전일 대비, bstp_nmix_prdy_ctrt: 전일 대비율
+  const sign   = o.prdy_vrss_sign ?? '3';
+  const absChg = parseFloat(o.bstp_nmix_prdy_vrss || '0');
+  const change = (sign === '4' || sign === '5') ? -absChg : absChg;
+
+  return {
+    value:     parseFloat(value.toFixed(2)),
+    change:    parseFloat(change.toFixed(2)),
+    changePct: parseFloat(o.bstp_nmix_prdy_ctrt || '0'),
+  };
+}
+
+export default async function handler(req, res) {
+  if (!process.env.HANTOO_APP_KEY || !process.env.HANTOO_APP_SECRET) {
+    return res.status(503).json({ error: 'HANTOO not configured' });
+  }
+
+  try {
+    const token   = await getHantooToken();
+    const settled = await Promise.allSettled(
+      INDICES.map(async ({ id, code }) => {
+        const data = await fetchSingleIndex(code, token);
+        return { id, ...data };
+      })
+    );
+
+    const data   = settled.filter(r => r.status === 'fulfilled').map(r => r.value);
+    const errors = settled.filter(r => r.status === 'rejected').map(r => r.reason?.message);
+
+    res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate=10');
+    res.json({ data, errors: errors.length ? errors : undefined });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+}

--- a/api/us-price.js
+++ b/api/us-price.js
@@ -79,15 +79,18 @@ export default async function handler(req) {
   }
 
   // Yahoo v8 1순위 (실시간), Stooq 2순위 (fallback)
-  const settled = await Promise.allSettled(
-    symbols.map(symbol =>
-      fetchYahooV8(symbol).catch(() => fetchStooqSingle(symbol))
-    )
-  );
-
-  const results = settled
-    .filter(r => r.status === 'fulfilled')
-    .map(r => r.value);
+  // 15개씩 청크 분할 — Yahoo rate limit 방지
+  const CHUNK = 15;
+  const results = [];
+  for (let i = 0; i < symbols.length; i += CHUNK) {
+    const chunk = symbols.slice(i, i + CHUNK);
+    const settled = await Promise.allSettled(
+      chunk.map(symbol =>
+        fetchYahooV8(symbol).catch(() => fetchStooqSingle(symbol))
+      )
+    );
+    results.push(...settled.filter(r => r.status === 'fulfilled').map(r => r.value));
+  }
 
   return new Response(JSON.stringify({ results }), {
     headers: {

--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -396,47 +396,71 @@ const ALL_INDICES = [
   { id: 'DXY',    symbol: 'DX-Y.NYB' },
 ];
 
+// 한투 업종지수 (KOSPI/KOSDAQ — 가장 정확한 실시간)
+async function fetchHantooIndices() {
+  const res = await fetch('/api/hantoo-indices', { signal: AbortSignal.timeout(8000) });
+  if (!res.ok) throw new Error(`한투 지수 ${res.status}`);
+  const json = await res.json();
+  return json.data || [];
+}
+
+const ALL_INDEX_IDS = ['KOSPI', 'KOSDAQ', 'SPX', 'NDX', 'DJI', 'DXY'];
+
 export async function fetchIndices() {
-  // 0) Vercel Edge 프록시 /api/market-indices — 서버사이드 직접 Yahoo 호출 (allorigins 불필요)
+  let results = [];
+
+  // 0) Vercel Edge 프록시 /api/market-indices — 서버사이드 직접 Yahoo 호출
   try {
     const res = await fetch('/api/market-indices', { signal: AbortSignal.timeout(10000) });
     if (res.ok) {
       const data = await res.json();
-      if (data.results?.length >= 3) return data.results;
+      if (data.results?.length > 0) results = data.results;
     }
   } catch {}
 
-  // 1) KOSPI: Stooq 1순위 → Yahoo fallback (allorigins 경유)
-  const kospiPromise = (async () => {
+  // 1) 누락된 지수 확인 — Edge 프록시가 부분 결과 반환 시 보충
+  const have = new Set(results.map(r => r.id));
+  const missing = ALL_INDEX_IDS.filter(id => !have.has(id));
+
+  if (missing.length === 0) return results;
+
+  // 2) KOSPI/KOSDAQ 누락 시 한투 API 보충 (가장 정확)
+  const missingKr = missing.filter(id => id === 'KOSPI' || id === 'KOSDAQ');
+  if (missingKr.length > 0) {
     try {
-      return await fetchStooqKospi();
-    } catch {
-      // Stooq 실패 시 Yahoo Finance fallback (최대 ~10분 지연 가능)
-      const result = await fetchYahooRace('^KS11', 'KOSPI');
-      return {
-        ...result,
-        isDelayed: true,    // Yahoo 경유 시 지연 가능성 있음
-        dataDelay: '~10분 지연',
-      };
-    }
-  })();
-
-  // KOSDAQ + 해외 지수: Yahoo Finance (지연 가능성 명시)
-  const otherResults = await Promise.allSettled(
-    ALL_INDICES.map(({ id, symbol }) => fetchYahooRace(symbol, id))
-  );
-
-  const others = otherResults
-    .filter(r => r.status === 'fulfilled')
-    .map(r => {
-      const v = r.value;
-      // KOSDAQ은 Yahoo 경유 — 지연 가능성 플래그
-      if (v.id === 'KOSDAQ') {
-        return { ...v, isDelayed: true, dataDelay: '~10분 지연' };
+      const hantooData = await fetchHantooIndices();
+      for (const idx of hantooData) {
+        if (missingKr.includes(idx.id)) {
+          results.push(idx);
+          have.add(idx.id);
+        }
       }
-      return { ...v, isDelayed: false, dataDelay: '실시간(추정)' };
+    } catch {}
+  }
+
+  // 3) 여전히 누락된 지수: Stooq(KOSPI) + Yahoo allorigins(나머지) fallback
+  const stillMissing = ALL_INDEX_IDS.filter(id => !have.has(id));
+  if (stillMissing.length > 0) {
+    const fallbackPromises = stillMissing.map(async (id) => {
+      if (id === 'KOSPI') {
+        try { return await fetchStooqKospi(); } catch {}
+        try {
+          const r = await fetchYahooRace('^KS11', 'KOSPI');
+          return { ...r, isDelayed: true, dataDelay: '~10분 지연' };
+        } catch {}
+        return null;
+      }
+      const entry = ALL_INDICES.find(x => x.id === id);
+      if (!entry) return null;
+      try { return await fetchYahooRace(entry.symbol, id); } catch {}
+      return null;
     });
 
-  const kospi = await kospiPromise.catch(() => null);
-  return [...(kospi ? [kospi] : []), ...others];
+    const settled = await Promise.allSettled(fallbackPromises);
+    for (const r of settled) {
+      if (r.status === 'fulfilled' && r.value) results.push(r.value);
+    }
+  }
+
+  return results;
 }


### PR DESCRIPTION
## Summary
- **fetchIndices 부분 결과 보충**: Edge 프록시가 6개 중 일부만 반환해도 누락 지수를 한투/Stooq/Yahoo로 개별 보충
- **api/hantoo-indices.js**: 한투 업종현재가 API 신규 (KOSPI/KOSDAQ 실시간)
- **api/us-price.js**: 60+종목 동시 요청 → 15개씩 청크 분할 (Yahoo rate limit 방지)

## Test plan
- [ ] 지수 6개 모두 표시 확인 (KOSPI, KOSDAQ, S&P 500, NASDAQ, DOW, USD Index)
- [ ] 미장 60+종목 가격 정상 수신 확인
- [ ] `curl /api/hantoo-indices` → KOSPI/KOSDAQ 값 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)