### PR TITLE
feat: 섹션 배치 최적화 — 급등/급락 승격 + 컴팩트 관심종목 + 섹터 미리보기

### DIFF
--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -18,7 +18,7 @@ export default function HomeDashboard({
 }) {
   const { data: allNews = [] } = useAllNewsQuery();
   const { watchlist, toggle, isWatched } = useWatchlist();
-  const [collapsed, setCollapsed] = useState(true);
+  const [sectorExpanded, setSectorExpanded] = useState(false);
 
   // 마켓 태그
   const krItems   = useMemo(() => [
@@ -93,7 +93,7 @@ export default function HomeDashboard({
       {/* ─── 경제 이벤트 티커 ─────────────────────────────── */}
       <EventTicker />
 
-      {/* ─── 관심종목 (빈 상태 시 인기 종목 추천) ──────────── */}
+      {/* ─── 관심종목 (컴팩트 — 4개 넘으면 스크롤) ──────── */}
       <WatchlistWidget
         watchedItems={watchedItems}
         popularItems={popularItems}
@@ -102,13 +102,7 @@ export default function HomeDashboard({
         krwRate={krwRate}
       />
 
-      {/* ─── 시장을 움직이는 뉴스 (종목 연결 카드) ──────────── */}
-      <NewsFeedWidget allNews={allNews} onNewsClick={onNewsClick} allItems={allItems} />
-
-      {/* ─── 시장 투자자 동향 ─────────────────────────────── */}
-      <MarketInvestorSection />
-
-      {/* ─── 급등/급락 6박스 ──────────────────────────────── */}
+      {/* ─── 급등/급락 6박스 (첫 화면에 걸치도록 승격) ──── */}
       <TopMoversWidget
         hasData={hasData}
         krHot={krHot} usHot={usHot} coinHot={coinHot}
@@ -117,24 +111,43 @@ export default function HomeDashboard({
         onItemClick={onItemClick}
       />
 
+      {/* ─── 시장을 움직이는 뉴스 (종목 연결 카드) ──────────── */}
+      <NewsFeedWidget allNews={allNews} onNewsClick={onNewsClick} allItems={allItems} />
+
+      {/* ─── 시장 투자자 동향 ─────────────────────────────── */}
+      <MarketInvestorSection />
+
       {/* ─── 코인 거래소 공지 ─────────────────────────────── */}
       <CoinListingSection />
 
-      {/* ─── 하단 접힘: 섹터 로테이션 ─────────────────────── */}
+      {/* ─── 섹터 로테이션 (미리보기 + 펼치기) ────────────── */}
       {(krStocks.length > 0 || usStocks.length > 0 || coins.length > 0) && (
-        <div>
-          <button
-            onClick={() => setCollapsed(p => !p)}
-            className="w-full flex items-center justify-center gap-2 py-2 text-[12px] text-[#8B95A1] hover:text-[#4E5968] transition-colors"
-          >
-            <div className="flex-1 h-px bg-[#F2F4F6]" />
-            <span>{collapsed ? '▼ 더보기 (섹터 로테이션)' : '▲ 접기'}</span>
-            <div className="flex-1 h-px bg-[#F2F4F6]" />
-          </button>
-          {!collapsed && (
-            <div className="mt-2">
-              <SectorRotation krStocks={krStocks} usStocks={usStocks} coins={coins} />
+        <div className="relative">
+          {/* 미리보기: 항상 헤더 + 상위 3개 HOT 섹터 표시 */}
+          <div className={sectorExpanded ? '' : 'max-h-[160px] overflow-hidden'}>
+            <SectorRotation krStocks={krStocks} usStocks={usStocks} coins={coins} />
+          </div>
+          {/* 접힌 상태일 때 하단 페이드 + 펼치기 버튼 */}
+          {!sectorExpanded && (
+            <div className="absolute bottom-0 left-0 right-0">
+              <div className="h-12 bg-gradient-to-t from-white to-transparent" />
+              <button
+                onClick={() => setSectorExpanded(true)}
+                className="w-full flex items-center justify-center gap-1 py-2 bg-white text-[12px] font-medium text-[#3182F6] hover:text-[#1764ED] transition-colors"
+              >
+                <span>섹터 로테이션 전체보기</span>
+                <span className="text-[10px]">▼</span>
+              </button>
             </div>
+          )}
+          {sectorExpanded && (
+            <button
+              onClick={() => setSectorExpanded(false)}
+              className="w-full flex items-center justify-center gap-1 py-2 text-[12px] text-[#8B95A1] hover:text-[#4E5968] transition-colors"
+            >
+              <span>접기</span>
+              <span className="text-[10px]">▲</span>
+            </button>
           )}
         </div>
       )}

--- a/src/components/home/widgets/WatchlistWidget.jsx
+++ b/src/components/home/widgets/WatchlistWidget.jsx
@@ -133,11 +133,17 @@ export default function WatchlistWidget({ watchedItems, popularItems = [], toggl
         <span className="text-[13px] font-bold text-[#191F28]">관심종목</span>
         <span className="text-[11px] text-[#B0B8C1]">{watchedItems.length}개</span>
       </div>
-      <div className="py-1 max-h-[280px] overflow-y-auto">
+      <div className="py-1 max-h-[180px] overflow-y-auto">
         {watchedItems.map(item => (
           <WatchRow key={item.id || item.symbol} item={item} krwRate={krwRate} onItemClick={onItemClick} onToggle={toggle} />
         ))}
       </div>
+      {/* 스크롤 힌트 — 4개 이상일 때 */}
+      {watchedItems.length > 4 && (
+        <div className="text-center py-1.5 text-[10px] text-[#B0B8C1] border-t border-[#F2F4F6]">
+          ↕ 스크롤하여 {watchedItems.length}개 종목 보기
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 급등/급락 6박스를 뉴스보다 위로 승격 → 첫 접속 화면에 걸쳐 보임
- 관심종목 max-h 280→180px 컴팩트화 + 4개 이상일 때 스크롤 힌트 표시
- 섹터 로테이션: 완전 숨김 → 헤더+상위 HOT 섹터 미리보기(160px) + 하단 페이드 그라데이션 + 펼치기 버튼

## 변경 후 레이아웃 순서
1. Market Pulse
2. 주목할 종목 (히어로)
3. 경제 이벤트 티커
4. 관심종목 (컴팩트)
5. **급등/급락 6박스** (승격)
6. 시장을 움직이는 뉴스
7. 투자자 동향
8. 코인 거래소 공지
9. 섹터 로테이션 (미리보기 + 펼치기)

## Test plan
- [ ] 모바일 첫 화면에서 급등/급락 상단이 보이는지 확인
- [ ] 관심종목 5개 이상 추가 시 스크롤 + 힌트 텍스트 표시
- [ ] 섹터 로테이션 미리보기 → 펼치기 → 접기 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)