### PR TITLE
fix: UX 피드백 일괄 수정 — 미장 changePct + 장 상태 필터링

### DIFF
--- a/api/us-price.js
+++ b/api/us-price.js
@@ -17,9 +17,14 @@ async function fetchYahooV8(symbol) {
   const closes = result.indicators?.quote?.[0]?.close?.filter(Boolean) ?? [];
   const price  = meta.regularMarketPrice;
   // chartPreviousClose는 차트 시작 기준점 — 전일 종가 아님, 사용 금지
-  const prev   = meta.previousClose
-    ?? (closes.length >= 2 ? closes[closes.length - 2] : null)
-    ?? price;
+  // previousClose가 현재가와 같거나 없으면 closes에서 현재가와 다른 가장 최근 값 사용
+  let prev = meta.previousClose;
+  if (!prev || prev === price) {
+    for (let i = closes.length - 2; i >= 0; i--) {
+      if (closes[i] && closes[i] !== price) { prev = closes[i]; break; }
+    }
+  }
+  if (!prev) prev = price;
   const change    = parseFloat((price - prev).toFixed(2));
   const changePct = prev > 0 ? parseFloat(((price - prev) / prev * 100).toFixed(2)) : 0;
   return {

--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -106,10 +106,15 @@ async function fetchYahooChart(symbol) {
   const meta   = result.meta;
   const closes = result.indicators?.quote?.[0]?.close?.filter(Boolean) ?? [];
   // chartPreviousClose는 차트 시작 기준점으로 전일 종가가 아님 — 사용 금지
-  // previousClose 없으면 closes[-2] (실제 직전 거래일 종가) 사용
-  const prev   = meta.previousClose
-    ?? (closes.length >= 2 ? closes[closes.length - 2] : null)
-    ?? meta.regularMarketPrice;
+  // previousClose가 현재가와 같거나 없으면 closes에서 현재가와 다른 가장 최근 값 사용
+  const curPrice = meta.regularMarketPrice;
+  let prev = meta.previousClose;
+  if (!prev || prev === curPrice) {
+    for (let i = closes.length - 2; i >= 0; i--) {
+      if (closes[i] && closes[i] !== curPrice) { prev = closes[i]; break; }
+    }
+  }
+  if (!prev) prev = curPrice;
   return {
     symbol:    meta.symbol?.split('.')[0],
     price:     meta.regularMarketPrice,

--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -3,13 +3,19 @@
 // 급등/급락 있을 때: 어두운 배경 강조
 // 없을 때: 중립 배경
 import { memo, useMemo } from 'react';
+import { getKoreanMarketStatus, getUsMarketStatus } from '../utils/marketHours';
 
 // React.memo: coins WS 틱마다 재렌더 방지 — 급등 순위 실제 변경 시에만 업데이트
 const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick }) {
   // 급등 종목 선별 (>=3%), 없으면 상위 5개
   const { items, hasHot } = useMemo(() => {
+    // 휴장 시장 제외 — 열린 시장 + 코인(24h)만
+    const krOpen = getKoreanMarketStatus().status === 'open';
+    const usOpen = getUsMarketStatus().status === 'open';
     const all = [
-      ...stocks.map(s => ({
+      ...stocks
+        .filter(s => s.market === 'kr' ? krOpen : s.market === 'us' ? usOpen : true)
+        .map(s => ({
         name:   s.name || s.symbol,
         symbol: s.symbol,
         pct:    s.changePct ?? 0,

--- a/src/components/home/HotListSection.jsx
+++ b/src/components/home/HotListSection.jsx
@@ -1,5 +1,6 @@
 import { memo, useState } from 'react';
 import { getPct, fmt, getAvatarBg, getLogoUrls } from './utils';
+import { getKoreanMarketStatus, getUsMarketStatus } from '../../utils/marketHours';
 
 // ─── SECTION 3: HOT 리스트 행 (3열 공통) ─────────────────────
 const HotRow = memo(function HotRow({ item, rank, krwRate, onClick }) {
@@ -81,21 +82,37 @@ function SkeletonHotRow({ count = 5 }) {
 }
 
 export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop, usDrop, coinDrop, krwRate, onItemClick }) {
+  const krOpen = getKoreanMarketStatus().status === 'open';
+  const usOpen = getUsMarketStatus().status === 'open';
+  const krLabel = getKoreanMarketStatus().label;
+  const usLabel = getUsMarketStatus().label;
+
+  // 휴장 시 표시할 오버레이
+  const ClosedOverlay = ({ label }) => (
+    <div className="px-4 py-8 text-center">
+      <span className="text-[13px] text-[#B0B8C1]">🌙 {label}</span>
+      <p className="text-[11px] text-[#C9CDD2] mt-1">전일 종가 기준</p>
+    </div>
+  );
+
   return (
     <>
       {/* ─── SECTION 3: 3열 HOT 리스트 ───────────────────────────────────────── */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         {/* 국내 급등 */}
-        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+        <div className={`bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm ${!krOpen ? 'opacity-60' : ''}`}>
           <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
             <div className="flex items-center gap-1.5">
               <span className="text-[13px]">🇰🇷</span>
               <span className="text-[13px] font-bold text-[#191F28]">국내 급등</span>
+              {!krOpen && <span className="text-[9px] text-[#B0B8C1] bg-[#F2F4F6] px-1.5 py-0.5 rounded">{krLabel}</span>}
             </div>
             <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#FFF0F0] text-[#F04452]">TOP 5</span>
           </div>
           <div className="py-1">
-            {!hasData
+            {!krOpen
+              ? <ClosedOverlay label={krLabel} />
+              : !hasData
               ? <SkeletonHotRow count={5} />
               : krHot.length > 0
                 ? krHot.map((item, i) => (
@@ -113,16 +130,19 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
         </div>
 
         {/* 미장 급등 */}
-        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+        <div className={`bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm ${!usOpen ? 'opacity-60' : ''}`}>
           <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
             <div className="flex items-center gap-1.5">
               <span className="text-[13px]">🇺🇸</span>
               <span className="text-[13px] font-bold text-[#191F28]">미장 급등</span>
+              {!usOpen && <span className="text-[9px] text-[#B0B8C1] bg-[#F2F4F6] px-1.5 py-0.5 rounded">{usLabel}</span>}
             </div>
             <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#3182F6]">TOP 5</span>
           </div>
           <div className="py-1">
-            {!hasData
+            {!usOpen
+              ? <ClosedOverlay label={usLabel} />
+              : !hasData
               ? <SkeletonHotRow count={5} />
               : usHot.length > 0
                 ? usHot.map((item, i) => (
@@ -170,16 +190,19 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
       {/* ─── SECTION 3b: 3열 DROP 리스트 ───── */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         {/* 국내 급락 */}
-        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+        <div className={`bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm ${!krOpen ? 'opacity-60' : ''}`}>
           <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
             <div className="flex items-center gap-1.5">
               <span className="text-[13px]">🇰🇷</span>
               <span className="text-[13px] font-bold text-[#191F28]">국내 급락</span>
+              {!krOpen && <span className="text-[9px] text-[#B0B8C1] bg-[#F2F4F6] px-1.5 py-0.5 rounded">{krLabel}</span>}
             </div>
             <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED]">TOP 5</span>
           </div>
           <div className="py-1">
-            {!hasData
+            {!krOpen
+              ? <ClosedOverlay label={krLabel} />
+              : !hasData
               ? <SkeletonHotRow count={5} />
               : krDrop.map((item, i) => (
                   <HotRow
@@ -195,16 +218,19 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
         </div>
 
         {/* 미장 급락 */}
-        <div className="bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm">
+        <div className={`bg-white rounded-2xl overflow-hidden border border-[#F2F4F6] shadow-sm ${!usOpen ? 'opacity-60' : ''}`}>
           <div className="flex items-center justify-between px-4 py-3 border-b border-[#F2F4F6]">
             <div className="flex items-center gap-1.5">
               <span className="text-[13px]">🇺🇸</span>
               <span className="text-[13px] font-bold text-[#191F28]">미장 급락</span>
+              {!usOpen && <span className="text-[9px] text-[#B0B8C1] bg-[#F2F4F6] px-1.5 py-0.5 rounded">{usLabel}</span>}
             </div>
             <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED]">TOP 5</span>
           </div>
           <div className="py-1">
-            {!hasData
+            {!usOpen
+              ? <ClosedOverlay label={usLabel} />
+              : !hasData
               ? <SkeletonHotRow count={5} />
               : usDrop.map((item, i) => (
                   <HotRow

--- a/src/components/home/MarketIndexSection.jsx
+++ b/src/components/home/MarketIndexSection.jsx
@@ -12,7 +12,12 @@ const IndexStripItem = memo(function IndexStripItem({ idx }) {
     <div className="flex-shrink-0 flex items-center gap-2 px-3 py-2 rounded-xl bg-white border border-[#F2F4F6] hover:border-[#D1D6DB] hover:bg-[#F7F8FA] cursor-default transition-colors">
       <span className="text-[12px]">{flag}</span>
       <span className="text-[11px] text-[#8B95A1] font-medium">{idx.name}</span>
-      <span className="text-[12px] font-bold tabular-nums font-mono" style={{ color }}>
+      {idx.price > 0 && (
+        <span className="text-[12px] font-bold text-[#191F28] tabular-nums font-mono">
+          {idx.price >= 1000 ? idx.price.toLocaleString('ko-KR', { maximumFractionDigits: 0 }) : idx.price.toFixed(2)}
+        </span>
+      )}
+      <span className="text-[11px] font-bold tabular-nums font-mono" style={{ color }}>
         {isUp ? '▲' : isDown ? '▼' : '—'}{Math.abs(idx.changePct ?? 0).toFixed(2)}%
       </span>
     </div>

--- a/src/components/home/NotableMoversSection.jsx
+++ b/src/components/home/NotableMoversSection.jsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import { getPct, fmt, getAvatarBg, getLogoUrls, findRelatedNews } from './utils';
 import { buildStockKeywords, matchesKeywords } from '../../utils/newsAlias';
+import { getKoreanMarketStatus, getUsMarketStatus } from '../../utils/marketHours';
 
 const MKT_BADGE = {
   KR:   { label: '국내', bg: '#FFF0F0', color: '#F04452' },
@@ -135,10 +136,21 @@ export default function NotableMoversSection({ allItems = [], recentNews = [], k
   const notables = useMemo(() => {
     if (!allItems.length) return [];
 
+    // 휴장 시장 필터링 — 열려있는 시장 + 코인(24h)만 포함
+    const krOpen = getKoreanMarketStatus().status === 'open';
+    const usOpen = getUsMarketStatus().status === 'open';
+    const activeItems = allItems.filter(item => {
+      if (item._market === 'COIN') return true;
+      if (item._market === 'KR') return krOpen;
+      if (item._market === 'US') return usOpen;
+      return true;
+    });
+    if (!activeItems.length) return [];
+
     // 마켓별 거래량 순위 계산
     const volumeRanks = new Map();
     const byMarket = { KR: [], US: [], COIN: [] };
-    for (const item of allItems) {
+    for (const item of activeItems) {
       const vol = item._market === 'COIN' ? (item.volume24h ?? 0) : (item.volume ?? 0);
       (byMarket[item._market] || []).push({ symbol: item.symbol || item.id, vol });
     }
@@ -147,7 +159,7 @@ export default function NotableMoversSection({ allItems = [], recentNews = [], k
       items.forEach((it, i) => volumeRanks.set(it.symbol, i + 1));
     }
 
-    return allItems
+    return activeItems
       .map(item => {
         const pct = Math.abs(getPct(item));
         const volRank = volumeRanks.get(item.symbol || item.id) || 999;

--- a/src/components/home/widgets/WatchlistWidget.jsx
+++ b/src/components/home/widgets/WatchlistWidget.jsx
@@ -133,15 +133,15 @@ export default function WatchlistWidget({ watchedItems, popularItems = [], toggl
         <span className="text-[13px] font-bold text-[#191F28]">관심종목</span>
         <span className="text-[11px] text-[#B0B8C1]">{watchedItems.length}개</span>
       </div>
-      <div className="py-1 max-h-[180px] overflow-y-auto">
+      <div className="py-1 max-h-[100px] overflow-y-auto">
         {watchedItems.map(item => (
           <WatchRow key={item.id || item.symbol} item={item} krwRate={krwRate} onItemClick={onItemClick} onToggle={toggle} />
         ))}
       </div>
-      {/* 스크롤 힌트 — 4개 이상일 때 */}
-      {watchedItems.length > 4 && (
+      {/* 스크롤 힌트 — 3개 이상일 때 */}
+      {watchedItems.length > 2 && (
         <div className="text-center py-1.5 text-[10px] text-[#B0B8C1] border-t border-[#F2F4F6]">
-          ↕ 스크롤하여 {watchedItems.length}개 종목 보기
+          ↕ {watchedItems.length}개 종목 · 워치리스트 탭에서 상세 보기
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- **미장 changePct=0 근본 수정**: Yahoo v8 closes 중복 시 현재가와 다른 최근 값으로 전일 종가 탐색
- **장 상태 필터링**: 주목할 종목·급등급락·롤링 배너에서 휴장 시장 종목 제외
- **마켓펄스 지수 절대값**: 변동률만 → 가격+변동률 동시 표시
- **관심종목 컴팩트**: 180→100px, 워치리스트 탭 유도

## Test plan
- [ ] 미장 종목 changePct ≠ 0 확인 (AAPL, NVDA, TSLA)
- [ ] 휴장 시간에 주목할 종목 = 코인만 표시
- [ ] 급등/급락 국내/미장 칸에 "🌙 휴장" 오버레이
- [ ] 마켓펄스 지수에 가격 숫자 표시
- [ ] 관심종목 영역 컴팩트하게 줄어듦

🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시장 폐장 시 상태 레이블 표시 추가

* **기능 개선**
  * 폐장 중인 시장의 종목 자동 필터링
  * 폐장 시 카드 투명도 조정 및 전일 종가 기준 표시
  * 지수 가격 표시 형식 최적화
  * 찜하기 목록 스크롤 높이 감소 및 알림 조건 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->