### PR TITLE
fix: 미장 changePct=0 — 부동소수점 비교 오차 수정

### DIFF
--- a/api/us-price.js
+++ b/api/us-price.js
@@ -18,10 +18,12 @@ async function fetchYahooV8(symbol) {
   const price  = meta.regularMarketPrice;
   // chartPreviousClose는 차트 시작 기준점 — 전일 종가 아님, 사용 금지
   // previousClose가 현재가와 같거나 없으면 closes에서 현재가와 다른 가장 최근 값 사용
+  // 부동소수점 비교: 0.01 이내 차이는 동일 가격으로 간주
+  const almostEqual = (a, b) => Math.abs(a - b) < 0.01;
   let prev = meta.previousClose;
-  if (!prev || prev === price) {
+  if (!prev || almostEqual(prev, price)) {
     for (let i = closes.length - 2; i >= 0; i--) {
-      if (closes[i] && closes[i] !== price) { prev = closes[i]; break; }
+      if (closes[i] && !almostEqual(closes[i], price)) { prev = closes[i]; break; }
     }
   }
   if (!prev) prev = price;

--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -107,11 +107,13 @@ async function fetchYahooChart(symbol) {
   const closes = result.indicators?.quote?.[0]?.close?.filter(Boolean) ?? [];
   // chartPreviousClose는 차트 시작 기준점으로 전일 종가가 아님 — 사용 금지
   // previousClose가 현재가와 같거나 없으면 closes에서 현재가와 다른 가장 최근 값 사용
+  // 부동소수점 비교: 0.01 이내 차이는 동일 가격으로 간주
   const curPrice = meta.regularMarketPrice;
+  const almostEq = (a, b) => Math.abs(a - b) < 0.01;
   let prev = meta.previousClose;
-  if (!prev || prev === curPrice) {
+  if (!prev || almostEq(prev, curPrice)) {
     for (let i = closes.length - 2; i >= 0; i--) {
-      if (closes[i] && closes[i] !== curPrice) { prev = closes[i]; break; }
+      if (closes[i] && !almostEq(closes[i], curPrice)) { prev = closes[i]; break; }
     }
   }
   if (!prev) prev = curPrice;


### PR DESCRIPTION
## Summary
- Yahoo v8 `regularMarketPrice`(247.99)와 closes 배열(247.99000549316406) 정밀도 차이로 동일 가격 비교 실패
- `almostEqual` (0.01 이내) 비교로 교체하여 전일 종가 정확 추출

## Test plan
- [ ] `/api/us-price?symbols=AAPL` → changePct ≠ 0 확인

🤖 Generated by Claude Code [claude-opus-4-6]