### PR TITLE
fix: Stooq 필드명 소문자 대응 + 지수 changePct=0 + 지수값 미표시 수정

### DIFF
--- a/api/market-indices.js
+++ b/api/market-indices.js
@@ -26,9 +26,16 @@ async function fetchYahooIndex(id, symbol) {
   const closes = result.indicators?.quote?.[0]?.close?.filter(Boolean) ?? [];
   const price  = meta.regularMarketPrice;
   // chartPreviousClose는 차트 시작 기준점 — 전일 종가 아님, 사용 금지
-  const prev   = meta.previousClose
-    ?? (closes.length >= 2 ? closes[closes.length - 2] : null)
-    ?? price;
+  // previousClose가 null이거나 현재가와 동일하면 closes 배열에서 이전 종가 탐색
+  // 부동소수점 비교: 0.01 이내 차이는 동일 가격으로 간주
+  const almostEqual = (a, b) => Math.abs(a - b) < 0.01;
+  let prev = meta.previousClose;
+  if (!prev || almostEqual(prev, price)) {
+    for (let i = closes.length - 2; i >= 0; i--) {
+      if (closes[i] && !almostEqual(closes[i], price)) { prev = closes[i]; break; }
+    }
+  }
+  if (!prev) prev = price;
   return {
     id,
     value:     parseFloat(price.toFixed(2)),
@@ -44,10 +51,11 @@ async function fetchStooqKospi() {
   });
   if (!res.ok) throw new Error(`Stooq KOSPI ${res.status}`);
   const data = await res.json();
-  const s = (data.symbols || []).find(x => x.Close && x.Close !== 'N/D');
+  // Stooq JSON 필드명: 소문자 (close, previous, volume 등)
+  const s = (data.symbols || []).find(x => (x.close || x.Close) && (x.close || x.Close) !== 'N/D');
   if (!s) throw new Error('Stooq KOSPI N/D');
-  const close    = parseFloat(s.Close);
-  const prevClose = parseFloat(s.Prev_Close) || 0;
+  const close    = parseFloat(s.close ?? s.Close);
+  const prevClose = parseFloat(s.previous ?? s.Prev_Close) || 0;
   return {
     id:        'KOSPI',
     value:     parseFloat(close.toFixed(2)),

--- a/api/us-price.js
+++ b/api/us-price.js
@@ -52,16 +52,19 @@ async function fetchStooqSingle(symbol) {
   });
   if (!res.ok) throw new Error(`Stooq ${res.status}`);
   const data = await res.json();
+  // Stooq JSON 필드명: 소문자 (close, previous, volume 등)
   const s = (data.symbols || [])[0];
-  if (!s || !s.Close || s.Close === 'N/D') throw new Error('N/D');
-  const close     = parseFloat(s.Close);
-  const prevClose = parseFloat(s.Prev_Close) || close;
+  if (!s) throw new Error('N/D');
+  const closeVal = s.close ?? s.Close;
+  if (!closeVal || closeVal === 'N/D') throw new Error('N/D');
+  const close     = parseFloat(closeVal);
+  const prevClose = parseFloat(s.previous ?? s.Prev_Close) || close;
   return {
     symbol,
     price:     parseFloat(close.toFixed(2)),
     change:    prevClose > 0 ? parseFloat((close - prevClose).toFixed(2)) : 0,
     changePct: prevClose > 0 ? parseFloat(((close - prevClose) / prevClose * 100).toFixed(2)) : 0,
-    volume:    parseInt(s.Volume) || 0,
+    volume:    parseInt(s.volume ?? s.Volume) || 0,
     marketCap: 0,
     high52w:   null,
     low52w:    null,

--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -27,20 +27,21 @@ async function fetchStooq(symbols) {
   const res  = await fetch(url, { signal: AbortSignal.timeout(5000) });
   if (!res.ok) throw new Error(`Stooq ${res.status}`);
   const data = await res.json();
+  // Stooq JSON 필드명: 소문자 (close, previous, volume, symbol 등)
   return (data.symbols || [])
-    .filter(s => s.Close && s.Close !== 'N/D' && parseFloat(s.Close) > 0)
+    .filter(s => (s.close ?? s.Close) && (s.close ?? s.Close) !== 'N/D' && parseFloat(s.close ?? s.Close) > 0)
     .map(s => {
-      const close     = parseFloat(s.Close);
-      // Prev_Close(p 필드) 전일 종가 — 없으면 change=0 (Open 근사는 오류 원인)
-      const prevClose = parseFloat(s.Prev_Close) || 0;
+      const close     = parseFloat(s.close ?? s.Close);
+      // previous(p 필드) 전일 종가 — 없으면 change=0
+      const prevClose = parseFloat(s.previous ?? s.Prev_Close) || 0;
       return {
-        symbol:    s.Symbol.split('.')[0].toUpperCase(),
+        symbol:    (s.symbol ?? s.Symbol).split('.')[0].toUpperCase(),
         price:     close,
         change:    prevClose > 0 ? parseFloat((close - prevClose).toFixed(2)) : 0,
         changePct: prevClose > 0
           ? parseFloat(((close - prevClose) / prevClose * 100).toFixed(2))
           : 0,
-        volume:    parseInt(s.Volume) || 0,
+        volume:    parseInt(s.volume ?? s.Volume) || 0,
         _source:   'stooq',
       };
     });
@@ -348,15 +349,22 @@ async function fetchYahooRace(symbol, id) {
         done = true;
         const meta   = result.meta;
         const closes = result.indicators?.quote?.[0]?.close?.filter(Boolean) ?? [];
+        const price  = meta.regularMarketPrice;
         // chartPreviousClose는 차트 시작 기준점 — 전일 종가 아님, 사용 금지
-        const prev = meta.previousClose
-          ?? (closes.length >= 2 ? closes[closes.length - 2] : null)
-          ?? meta.regularMarketPrice;
+        // previousClose가 null이거나 현재가와 동일하면 closes에서 이전 종가 탐색
+        const almostEq = (a, b) => Math.abs(a - b) < 0.01;
+        let prev = meta.previousClose;
+        if (!prev || almostEq(prev, price)) {
+          for (let i = closes.length - 2; i >= 0; i--) {
+            if (closes[i] && !almostEq(closes[i], price)) { prev = closes[i]; break; }
+          }
+        }
+        if (!prev) prev = price;
         resolve({
           id,
-          value:     parseFloat(meta.regularMarketPrice.toFixed(2)),
-          change:    parseFloat((meta.regularMarketPrice - prev).toFixed(2)),
-          changePct: parseFloat(((meta.regularMarketPrice - prev) / prev * 100).toFixed(2)),
+          value:     parseFloat(price.toFixed(2)),
+          change:    parseFloat((price - prev).toFixed(2)),
+          changePct: parseFloat(((price - prev) / prev * 100).toFixed(2)),
         });
       }).catch(() => {
         failed++;
@@ -378,11 +386,12 @@ async function fetchStooqKospi() {
   });
   if (!res.ok) throw new Error(`Stooq KOSPI ${res.status}`);
   const data = await res.json();
-  const s = (data.symbols || []).find(x => x.Close && x.Close !== 'N/D');
+  // Stooq JSON 필드명: 소문자 (close, previous 등)
+  const s = (data.symbols || []).find(x => (x.close ?? x.Close) && (x.close ?? x.Close) !== 'N/D');
   if (!s) throw new Error('Stooq KOSPI: N/D');
-  const close     = parseFloat(s.Close);
-  // Prev_Close(p 필드) 전일 종가 기준 — 없으면 change=0 (Open 근사 제거)
-  const prevClose = parseFloat(s.Prev_Close) || 0;
+  const close     = parseFloat(s.close ?? s.Close);
+  // previous(p 필드) 전일 종가 기준 — 없으면 change=0
+  const prevClose = parseFloat(s.previous ?? s.Prev_Close) || 0;
   return {
     id:        'KOSPI',
     value:     parseFloat(close.toFixed(2)),

--- a/src/components/home/MarketIndexSection.jsx
+++ b/src/components/home/MarketIndexSection.jsx
@@ -12,9 +12,9 @@ const IndexStripItem = memo(function IndexStripItem({ idx }) {
     <div className="flex-shrink-0 flex items-center gap-2 px-3 py-2 rounded-xl bg-white border border-[#F2F4F6] hover:border-[#D1D6DB] hover:bg-[#F7F8FA] cursor-default transition-colors">
       <span className="text-[12px]">{flag}</span>
       <span className="text-[11px] text-[#8B95A1] font-medium">{idx.name}</span>
-      {idx.price > 0 && (
+      {idx.value > 0 && (
         <span className="text-[12px] font-bold text-[#191F28] tabular-nums font-mono">
-          {idx.price >= 1000 ? idx.price.toLocaleString('ko-KR', { maximumFractionDigits: 0 }) : idx.price.toFixed(2)}
+          {idx.value >= 1000 ? idx.value.toLocaleString('ko-KR', { maximumFractionDigits: 0 }) : idx.value.toFixed(2)}
         </span>
       )}
       <span className="text-[11px] font-bold tabular-nums font-mono" style={{ color }}>


### PR DESCRIPTION
## Summary
- Stooq API 소문자 필드명 대응 (close, previous, volume) — Stooq fallback 완전 복구
- Yahoo v8 지수 previousClose: null 대응 — almostEqual 비교 로직 적용
- MarketIndexSection idx.price → idx.value 수정 — 지수 값 UI 표시 복구

## 근본 원인
1. **Stooq fallback 미작동**: Stooq JSON이 소문자 필드명(`close`, `previous`) 반환, 코드는 대문자(`Close`, `Prev_Close`) 참조 → `undefined` → 데이터 0 또는 누락
2. **지수 changePct=0**: Yahoo v8가 `previousClose: null` 반환, `closes[-2]`가 현재가와 float 정밀도 차이(0.00002)로 동일 판정 실패 → `almostEqual` 미적용
3. **지수 값 미표시**: 지수 데이터가 `value` 필드 사용하는데 UI가 `idx.price` 참조 → 항상 `undefined`

## 영향 범위
- `api/us-price.js` — Stooq fallback 복구
- `api/market-indices.js` — Stooq KOSPI + Yahoo 지수 changePct 수정
- `src/api/stocks.js` — 클라이언트 Stooq + fetchYahooRace 수정
- `src/components/home/MarketIndexSection.jsx` — 지수 값 표시 수정

## Test plan
- [ ] `/api/market-indices` 호출 시 6개 지수 changePct ≠ 0 확인
- [ ] `/api/us-price?symbols=AAPL,NVDA` 호출 정상 확인
- [ ] 홈 화면 시장 지수 스트립에 지수 값(숫자) 표시 확인
- [ ] Stooq fallback 시 changePct 정상 계산 확인

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 시장 지수 및 주식 가격 데이터 조회의 안정성을 강화하여 외부 데이터 소스의 필드 변동성에 더 견고하게 대응
* 이전 종가 데이터 처리를 개선하여 누락된 데이터 시 대체 값을 더 정확하게 산출

## 개선사항
* 시장 지수 값 표시 로직을 일관되게 개선하여 정상적인 데이터 표시 보장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->