### PR TITLE
fix: UX 피드백 2차 — 거래소 감지·섹터 분리·뉴스 매칭·배너 개선

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import ChartSidePanel from './components/ChartSidePanel';
 import NewsSidePanel from './components/NewsSidePanel';
 import HomeDashboard from './components/home';
 import GlobalSearch from './components/GlobalSearch';
+import SectorRotation from './components/SectorRotation';
 
 import { ETF_DATA } from './data/mock';
 import { fetchKoreanStocksBatch, fetchEtfPricesBatch } from './api/stocks';
@@ -153,7 +154,7 @@ export default function App() {
   return (
     <div className="min-h-screen bg-[#F8F9FA]">
       <div className="sticky top-0 z-20">
-        <SurgeBanner stocks={allStocks} coins={coins} onClick={setSelectedItem} />
+        <SurgeBanner stocks={allStocks} coins={coins} indices={indices} onClick={setSelectedItem} />
       </div>
 
       {notifBanner && (
@@ -184,6 +185,8 @@ export default function App() {
               coins={coins} etfs={mergedEtfs} krwRate={krwRate}
               onItemClick={setSelectedItem} onNewsClick={setSelectedNews}
             />
+          ) : activeTab === 'sector' ? (
+            <SectorRotation krStocks={krStocks} usStocks={usStocks} coins={coins} />
           ) : activeTab === 'news' ? (
             <div className="lg:hidden h-[calc(100vh-112px)]">
               <BreakingNewsPanel coins={coins} onItemClick={setSelectedItem} onNewsClick={setSelectedNews} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,6 +9,7 @@ const TABS = [
   { id: 'us',   label: '🇺🇸 미장' },
   { id: 'coin', label: '🪙 코인' },
   { id: 'etf',  label: '📊 ETF' },
+  { id: 'sector', label: '🔄 섹터' },
   // 모바일 전용 뉴스 탭 — 데스크탑에서는 우측 고정 패널이 담당
   { id: 'news', label: '📰 뉴스', mobileOnly: true },
 ];

--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -1,14 +1,13 @@
 // 급등/급락 ticker 배너 — 상단 sticky
-// 급등(>=3%) + 급락(<=-3%) 종목 표시, 없으면 상위 5개 (절댓값 기준)
-// 급등/급락 있을 때: 어두운 배경 강조
-// 없을 때: 중립 배경
+// 급등(>=3%) + 급락(<=-3%) 종목 표시
+// 급등/급락 없을 때: 시장 지수 요약 표시 (실질적 정보 제공)
 import { memo, useMemo } from 'react';
 import { getKoreanMarketStatus, getUsMarketStatus } from '../utils/marketHours';
 
 // React.memo: coins WS 틱마다 재렌더 방지 — 급등 순위 실제 변경 시에만 업데이트
-const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick }) {
-  // 급등 종목 선별 (>=3%), 없으면 상위 5개
-  const { items, hasHot } = useMemo(() => {
+const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], indices = [], onClick }) {
+  // 급등 종목 선별 (>=3%), 없으면 지수 요약 표시
+  const { items, hasHot, isIndexMode } = useMemo(() => {
     // 휴장 시장 제외 — 열린 시장 + 코인(24h)만
     const krOpen = getKoreanMarketStatus().status === 'open';
     const usOpen = getUsMarketStatus().status === 'open';
@@ -40,15 +39,30 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick
 
     let base;
     if (hasHot) {
-      // 급등 최대 10개 + 급락 최대 10개 (총 최대 20개)
       base = [...surges.slice(0, 10), ...drops.slice(0, 10)];
+    } else if (indices.length > 0) {
+      // 급등/급락 없을 때: 지수 요약 모드
+      const idxItems = indices
+        .filter(idx => idx.value > 0)
+        .map(idx => ({
+          name: idx.name, symbol: idx.id,
+          pct: idx.changePct ?? 0, market: 'index', _raw: null,
+          _value: idx.value,
+        }));
+      // 지수 + 변동률 상위 종목 3개 혼합
+      const topMovers = [...all]
+        .filter(i => Math.abs(i.pct) >= 1)
+        .sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct))
+        .slice(0, 3);
+      base = [...idxItems, ...topMovers];
+      if (!base.length) base = [...all].sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct)).slice(0, 5);
+      return { items: [...base, ...base], hasHot: false, isIndexMode: true };
     } else {
-      // 급등/급락 없으면 절댓값 상위 5개
       base = [...all].sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct)).slice(0, 5);
     }
     // 무한 스크롤 효과를 위해 2배 복제
-    return { items: [...base, ...base], hasHot };
-  }, [stocks, coins]);
+    return { items: [...base, ...base], hasHot, isIndexMode: false };
+  }, [stocks, coins, indices]);
 
   if (!items.length) return null;
 
@@ -76,7 +90,7 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick
           className="text-[10px] font-bold tracking-widest uppercase"
           style={{ color: hasHot ? 'rgba(255,107,119,0.9)' : 'rgba(255,255,255,0.35)' }}
         >
-          {hasHot ? '🔥 급등·급락' : '시세'}
+          {hasHot ? '🔥 급등·급락' : isIndexMode ? '📊 시장' : '시세'}
         </span>
       </div>
 
@@ -97,6 +111,12 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], onClick
             </span>
             {/* 이름 */}
             <span style={{ color: 'rgba(255,255,255,0.4)' }}>{item.name}</span>
+            {/* 지수 모드: 지수 값 표시 */}
+            {item._value > 0 && (
+              <span className="font-mono tabular-nums" style={{ color: 'rgba(255,255,255,0.7)' }}>
+                {item._value >= 1000 ? item._value.toLocaleString('ko-KR', { maximumFractionDigits: 0 }) : item._value.toFixed(2)}
+              </span>
+            )}
             {/* 등락률 배지 */}
             <span
               className="font-bold tabular-nums px-1.5 py-0.5 rounded-full text-[10px]"

--- a/src/components/home/CoinListingSection.jsx
+++ b/src/components/home/CoinListingSection.jsx
@@ -1,9 +1,10 @@
-// 코인 거래소 공지 섹션 — Upbit 공지사항 API로 신규상장/상장폐지/이벤트 공지 표시
-import { useQuery } from '@tanstack/react-query';
+// 코인 거래소 공지 섹션 — 뉴스 기반 상장/상폐 감지
+// Upbit 공지 API 폐지(404) → 뉴스 피드에서 거래소 관련 키워드 필터링
+import { useMemo } from 'react';
+import { useAllNewsQuery } from '../../hooks/useNewsQuery';
 
-// ─── 공지 유형 분류 ──────────────────────────────────────
-// Upbit 공지 제목 패턴 기반으로 유형 결정
-const LISTING_TYPES = [
+// ─── 거래소 공지 유형 분류 ───────────────────────────────
+const LISTING_PATTERNS = [
   {
     type: 'new',
     label: '신규상장',
@@ -11,17 +12,7 @@ const LISTING_TYPES = [
     bg: '#F0FFF4',
     color: '#2AC769',
     borderColor: '#BBF7D0',
-    // 신규 상장 패턴
-    patterns: [
-      '디지털 자산 추가',
-      '원화 마켓 추가',
-      'BTC 마켓 추가',
-      'USDT 마켓 추가',
-      '마켓 디지털 자산 추가',
-      '신규 상장',
-      '거래 지원 안내',
-      '거래 지원 시작',
-    ],
+    keywords: ['상장', '거래 지원', '마켓 추가', '신규 코인', '코인 추가', '거래 시작', 'listing'],
   },
   {
     type: 'delist',
@@ -30,13 +21,7 @@ const LISTING_TYPES = [
     bg: '#FFF5F5',
     color: '#F04452',
     borderColor: '#FECACA',
-    patterns: [
-      '거래 지원 종료',
-      '상장폐지',
-      '유의 종목',
-      '투자유의',
-      '거래 정지',
-    ],
+    keywords: ['상장폐지', '거래 종료', '거래 정지', '유의 종목', '투자유의', 'delist'],
   },
   {
     type: 'event',
@@ -45,24 +30,19 @@ const LISTING_TYPES = [
     bg: '#FFFBEB',
     color: '#F59E0B',
     borderColor: '#FDE68A',
-    patterns: ['이벤트', '에어드랍', '스테이킹', '프로모션'],
+    keywords: ['에어드랍', '에어드롭', '스테이킹', '하드포크', 'airdrop', '네트워크 업그레이드'],
   },
 ];
 
-// 공지 유형 매칭
-function classifyNotice(title) {
-  for (const t of LISTING_TYPES) {
-    if (t.patterns.some(p => title.includes(p))) return t;
+// 거래소 이름 필터 — 이 거래소 키워드가 포함된 뉴스만 매칭
+const EXCHANGE_KW = ['업비트', '빗썸', '코인원', '코빗', '바이낸스', 'upbit', 'bithumb', 'binance', 'coinbase'];
+
+function classifyNews(title) {
+  const lower = title.toLowerCase();
+  for (const p of LISTING_PATTERNS) {
+    if (p.keywords.some(k => lower.includes(k))) return p;
   }
-  // 기타 → 일반
-  return {
-    type: 'general',
-    label: '공지',
-    icon: '📌',
-    bg: '#F8F9FA',
-    color: '#6B7684',
-    borderColor: '#E5E8EB',
-  };
+  return null;
 }
 
 // ─── 시간 포맷 ───────────────────────────────────────────
@@ -77,137 +57,89 @@ function timeAgo(dateStr) {
     if (hrs < 24) return `${hrs}시간 전`;
     const days = Math.floor(hrs / 24);
     return `${days}일 전`;
-  } catch {
-    return '';
-  }
-}
-
-// ─── Upbit 공지 API 호출 ─────────────────────────────────
-// /api/upbit-notices 프록시 경유 (CORS 처리)
-async function fetchCoinListings() {
-  const res = await fetch('/api/upbit-notices', {
-    signal: AbortSignal.timeout(8000),
-  });
-  if (!res.ok) throw new Error(`공지 API 실패: ${res.status}`);
-
-  const json = await res.json();
-  // Upbit 응답 구조: { data: [...] } 또는 배열 직접 반환
-  const items = Array.isArray(json) ? json : (json.data || []);
-
-  // 신규상장·상장폐지·이벤트 필터 + 최대 5건
-  return items
-    .slice(0, 20)
-    .map(n => ({
-      id: n.id,
-      title: n.title || n.subject || '',
-      url: n.url || n.link || `https://upbit.com/service_center/notice?id=${n.id}`,
-      createdAt: n.created_at || n.created || '',
-      ...classifyNotice(n.title || n.subject || ''),
-    }))
-    .filter(n => n.type !== 'general')   // 일반 공지 제외
-    .slice(0, 5);
+  } catch { return ''; }
 }
 
 // ─── 공지 아이템 행 ─────────────────────────────────────
 function NoticeRow({ item }) {
   return (
     <a
-      href={item.url}
+      href={item.link}
       target="_blank"
       rel="noopener noreferrer"
       className="flex items-start gap-2.5 px-4 py-2.5 border-b border-[#F8F9FA] last:border-0 hover:bg-[#FAFBFC] transition-colors cursor-pointer"
     >
-      {/* 유형 뱃지 */}
       <span
         className="flex-shrink-0 text-[10px] font-bold px-1.5 py-0.5 rounded mt-0.5"
         style={{ background: item.bg, color: item.color, border: `1px solid ${item.borderColor}` }}
       >
         {item.icon} {item.label}
       </span>
-
-      {/* 공지 제목 */}
       <div className="flex-1 min-w-0">
         <span className="text-[13px] font-medium text-[#191F28] line-clamp-2 leading-snug">
           {item.title}
         </span>
+        {item.source && (
+          <span className="text-[10px] text-[#B0B8C1] mt-0.5 block">{item.source}</span>
+        )}
       </div>
-
-      {/* 시간 */}
       <span className="flex-shrink-0 text-[11px] text-[#B0B8C1] mt-0.5 whitespace-nowrap">
-        {timeAgo(item.createdAt)}
+        {timeAgo(item.pubDate)}
       </span>
     </a>
   );
 }
 
-// ─── 스켈레톤 로딩 ───────────────────────────────────────
-function ListingSkeleton() {
-  return (
-    <div className="space-y-0">
-      {Array.from({ length: 3 }).map((_, i) => (
-        <div key={i} className="flex items-center gap-2.5 px-4 py-2.5 border-b border-[#F8F9FA]">
-          <div className="w-14 h-4 bg-[#F2F4F6] rounded animate-pulse flex-shrink-0" />
-          <div className="flex-1 h-4 bg-[#F2F4F6] rounded animate-pulse" />
-          <div className="w-12 h-3 bg-[#F2F4F6] rounded animate-pulse flex-shrink-0" />
-        </div>
-      ))}
-    </div>
-  );
-}
-
 // ─── 메인 컴포넌트 ────────────────────────────────────────
 export default function CoinListingSection() {
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['coin-listings'],
-    queryFn: fetchCoinListings,
-    staleTime: 300_000,          // 5분 캐시
-    retry: 1,
-    refetchOnWindowFocus: false,
-  });
+  const { data: allNews = [], isLoading } = useAllNewsQuery();
 
-  // API 실패 시 섹션 전체 숨김
-  if (isError) return null;
+  // 뉴스에서 거래소 상장/상폐/이벤트 관련 기사 필터
+  const notices = useMemo(() => {
+    if (!allNews.length) return [];
+    const lower = t => (t || '').toLowerCase();
+    return allNews
+      .filter(n => {
+        const text = lower(n.title);
+        // 거래소 키워드 포함 필수
+        if (!EXCHANGE_KW.some(k => text.includes(k))) return false;
+        // 상장/상폐/이벤트 유형 매칭
+        return classifyNews(n.title || '') !== null;
+      })
+      .slice(0, 5)
+      .map(n => {
+        const type = classifyNews(n.title || '');
+        return { ...n, ...type, title: n.title || '' };
+      });
+  }, [allNews]);
 
-  // 데이터 로드 완료 후 표시할 공지 없으면 숨김
-  if (!isLoading && (!data || data.length === 0)) return null;
+  // 데이터 없으면 숨김
+  if (!isLoading && notices.length === 0) return null;
 
   return (
     <div className="bg-white rounded-2xl border border-[#F2F4F6] shadow-sm overflow-hidden">
-      {/* 헤더 */}
       <div className="flex items-center justify-between px-4 pt-4 pb-3 border-b border-[#F2F4F6]">
         <div className="flex items-center gap-2">
           <span className="text-[16px]">📢</span>
-          <span className="text-[15px] font-bold text-[#191F28]">코인 거래소 공지</span>
+          <span className="text-[15px] font-bold text-[#191F28]">거래소 상장·이벤트</span>
         </div>
-        <div className="flex items-center gap-1.5">
-          <span className="text-[11px] text-[#B0B8C1]">업비트 기준</span>
-          {/* 실시간 표시 인디케이터 */}
-          <span className="w-1.5 h-1.5 rounded-full bg-[#2AC769] animate-pulse" />
-        </div>
+        <span className="text-[11px] text-[#B0B8C1]">뉴스 기반 감지</span>
       </div>
 
-      {/* 공지 목록 */}
       <div>
         {isLoading ? (
-          <ListingSkeleton />
+          <div className="space-y-0">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-2.5 px-4 py-2.5 border-b border-[#F8F9FA]">
+                <div className="w-14 h-4 bg-[#F2F4F6] rounded animate-pulse flex-shrink-0" />
+                <div className="flex-1 h-4 bg-[#F2F4F6] rounded animate-pulse" />
+              </div>
+            ))}
+          </div>
         ) : (
-          data?.map(item => <NoticeRow key={item.id} item={item} />)
+          notices.map((item, i) => <NoticeRow key={i} item={item} />)
         )}
       </div>
-
-      {/* 하단 링크 */}
-      {!isLoading && data && data.length > 0 && (
-        <div className="px-4 py-2 border-t border-[#F8F9FA]">
-          <a
-            href="https://upbit.com/service_center/notice"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[12px] text-[#3182F6] font-medium hover:underline"
-          >
-            업비트 공지 전체 보기 →
-          </a>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -1,5 +1,4 @@
-import { useState, useMemo } from 'react';
-import SectorRotation from '../SectorRotation';
+import { useMemo } from 'react';
 import { useAllNewsQuery } from '../../hooks/useNewsQuery';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import { getPct } from './utils';
@@ -12,13 +11,71 @@ import MarketInvestorSection from './MarketInvestorSection';
 import EventTicker from './EventTicker';
 import CoinListingSection from './CoinListingSection';
 
+// ─── 섹터 미니 위젯 (HOT 3 + COLD 3 칩 → 섹터 탭 유도) ──
+function SectorMiniWidget({ krStocks, usStocks, coins }) {
+  const sectors = useMemo(() => {
+    const coinsWithPct = coins.filter(c => c.sector).map(c => ({ ...c, changePct: c.change24h ?? 0 }));
+    const items = [...krStocks, ...usStocks, ...coinsWithPct];
+    const map = {};
+    for (const s of items) {
+      if (!s.sector) continue;
+      if (!map[s.sector]) map[s.sector] = { sum: 0, count: 0 };
+      map[s.sector].sum += s.changePct ?? 0;
+      map[s.sector].count += 1;
+    }
+    return Object.entries(map)
+      .map(([name, { sum, count }]) => ({ name, avg: parseFloat((sum / count).toFixed(2)) }))
+      .sort((a, b) => b.avg - a.avg);
+  }, [krStocks, usStocks, coins]);
+
+  if (!sectors.length) return null;
+
+  const hot  = sectors.filter(s => s.avg > 0).slice(0, 3);
+  const cold = [...sectors.filter(s => s.avg <= 0)].reverse().slice(0, 3);
+
+  return (
+    <div className="bg-white rounded-2xl border border-[#F2F4F6] shadow-sm p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] font-bold text-[#191F28]">섹터 자금 흐름</span>
+          <span className="text-[10px] text-[#B0B8C1]">HOT · COLD</span>
+        </div>
+        <span className="text-[11px] text-[#3182F6] font-medium">섹터 탭에서 상세 →</span>
+      </div>
+      <div className="flex gap-4">
+        {/* HOT */}
+        <div className="flex-1">
+          <span className="text-[10px] font-bold text-[#F04452] uppercase mb-1.5 block">HOT</span>
+          <div className="flex flex-wrap gap-1.5">
+            {hot.length > 0 ? hot.map(s => (
+              <span key={s.name} className="text-[11px] font-medium px-2 py-1 rounded-lg bg-[#FFF0F1] text-[#F04452]">
+                {s.name} +{s.avg.toFixed(1)}%
+              </span>
+            )) : <span className="text-[10px] text-[#B0B8C1]">없음</span>}
+          </div>
+        </div>
+        {/* COLD */}
+        <div className="flex-1">
+          <span className="text-[10px] font-bold text-[#1764ED] uppercase mb-1.5 block">COLD</span>
+          <div className="flex flex-wrap gap-1.5">
+            {cold.length > 0 ? cold.map(s => (
+              <span key={s.name} className="text-[11px] font-medium px-2 py-1 rounded-lg bg-[#EDF4FF] text-[#1764ED]">
+                {s.name} {s.avg.toFixed(1)}%
+              </span>
+            )) : <span className="text-[10px] text-[#B0B8C1]">없음</span>}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function HomeDashboard({
   indices = [], krStocks = [], usStocks = [], coins = [], etfs = [],
   krwRate = 1466, onItemClick, onNewsClick,
 }) {
   const { data: allNews = [] } = useAllNewsQuery();
   const { watchlist, toggle, isWatched } = useWatchlist();
-  const [sectorExpanded, setSectorExpanded] = useState(false);
 
   // 마켓 태그
   const krItems   = useMemo(() => [
@@ -120,36 +177,9 @@ export default function HomeDashboard({
       {/* ─── 코인 거래소 공지 ─────────────────────────────── */}
       <CoinListingSection />
 
-      {/* ─── 섹터 로테이션 (미리보기 + 펼치기) ────────────── */}
+      {/* ─── 섹터 로테이션 미니 (HOT 3 + COLD 3 칩 → 섹터 탭 유도) ── */}
       {(krStocks.length > 0 || usStocks.length > 0 || coins.length > 0) && (
-        <div className="relative">
-          {/* 미리보기: 항상 헤더 + 상위 3개 HOT 섹터 표시 */}
-          <div className={sectorExpanded ? '' : 'max-h-[160px] overflow-hidden'}>
-            <SectorRotation krStocks={krStocks} usStocks={usStocks} coins={coins} />
-          </div>
-          {/* 접힌 상태일 때 하단 페이드 + 펼치기 버튼 */}
-          {!sectorExpanded && (
-            <div className="absolute bottom-0 left-0 right-0">
-              <div className="h-12 bg-gradient-to-t from-white to-transparent" />
-              <button
-                onClick={() => setSectorExpanded(true)}
-                className="w-full flex items-center justify-center gap-1 py-2 bg-white text-[12px] font-medium text-[#3182F6] hover:text-[#1764ED] transition-colors"
-              >
-                <span>섹터 로테이션 전체보기</span>
-                <span className="text-[10px]">▼</span>
-              </button>
-            </div>
-          )}
-          {sectorExpanded && (
-            <button
-              onClick={() => setSectorExpanded(false)}
-              className="w-full flex items-center justify-center gap-1 py-2 text-[12px] text-[#8B95A1] hover:text-[#4E5968] transition-colors"
-            >
-              <span>접기</span>
-              <span className="text-[10px]">▲</span>
-            </button>
-          )}
-        </div>
+        <SectorMiniWidget krStocks={krStocks} usStocks={usStocks} coins={coins} />
       )}
     </div>
   );

--- a/src/utils/newsAlias.js
+++ b/src/utils/newsAlias.js
@@ -102,7 +102,7 @@ export const KR_ALIASES = {
 export const US_ALIASES = {
   'NVDA':  ['엔비디아', 'nvidia'],
   'AAPL':  ['애플', 'apple'],
-  'MSFT':  ['마이크로소프트', 'microsoft', 'ms'],
+  'MSFT':  ['마이크로소프트', 'microsoft'],
   'GOOGL': ['구글', '알파벳', 'google', 'alphabet'],
   'GOOG':  ['구글', '알파벳', 'google', 'alphabet'],
   'META':  ['메타', '페이스북', 'facebook'],
@@ -208,12 +208,28 @@ export function buildStockKeywords(symbol, name, market) {
   return [...keys].filter(k => k.length >= 2 && !/^\d{6}$/.test(k));
 }
 
+// ─── 짧은 영문 키워드 — 다른 단어의 부분 문자열이 되기 쉬운 것들 ──
+// 이 목록에 포함된 키워드는 길이와 무관하게 항상 단어 경계 매칭 적용
+const BOUNDARY_FORCE = new Set([
+  'arm', 'meta', 'coin', 'near', 'ton', 'uni', 'link', 'sand',
+  'atom', 'op', 'sol', 'apt', 'sui', 'inj',
+]);
+
 // ─── 스마트 텍스트 매칭 ────────────────────────────────────
-// 짧은 키워드(≤2자)는 단어 경계 매칭, 긴 것은 includes
+// 짧은 키워드(≤4자 영문) + 거짓양성 위험 키워드는 단어 경계 매칭
+// 한글 키워드(3자+)와 긴 영문(5자+)은 includes 사용
 export function matchesKeywords(text, keywords) {
   const lowerText = text.toLowerCase();
   return keywords.some(kw => {
-    if (isShortKeyword(kw)) {
+    // 단어 경계 매칭 필요 여부 판단:
+    // 1) isShortKeyword (영문 ≤2자, 한글 ≤2자)
+    // 2) 영문 3~4자 (arm, meta, coin 등 거짓양성 위험)
+    // 3) BOUNDARY_FORCE 목록에 포함
+    const needBoundary = isShortKeyword(kw)
+      || BOUNDARY_FORCE.has(kw)
+      || (/^[a-z0-9]{3,4}$/i.test(kw));
+
+    if (needBoundary) {
       // 단어 경계: 앞뒤가 공백/문장부호/시작/끝이어야 함
       // 한글 조사(가,이,을,의...)가 붙은 경우도 허용 (예: 기아가)
       try {


### PR DESCRIPTION
## Summary

- **거래소 상장 감지**: Upbit 공지 API 폐지(404) → 뉴스 피드 기반 상장/상폐/이벤트 키워드 필터링으로 전환
- **섹터 분리**: 홈에서 HOT 3 + COLD 3 미니 칩만 노출, 전체 SectorRotation은 별도 '섹터' 탭으로 이동
- **뉴스-종목 매칭 오탐 수정**: 3~4자 영문 키워드에도 word boundary 적용, 'ms' 별칭 제거 (samsung 오탐 방지)
- **상단 롤링 배너**: 급등/급락 없을 때 시장 지수 + 변동률 상위 종목 혼합 표시 (빈 배너 대신 유용한 정보)

## Test plan

- [ ] 홈 대시보드에서 섹터 미니 위젯(HOT/COLD 칩) 표시 확인
- [ ] 헤더에 '섹터' 탭 표시, 클릭 시 전체 SectorRotation 표시
- [ ] 거래소 상장 섹션: 뉴스에 거래소+상장 키워드 포함 기사만 표시
- [ ] 뉴스 클릭 시 종목 매칭에 쌩뚱맞은 종목 없는지 확인 (arm, coin, meta 등)
- [ ] 급등/급락 없을 때 상단 배너에 시장 지수 표시

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새로운 "섹터" 탭 추가로 섹터 회전 분석 기능 제공
  * 홈페이지에 HOT/COLD 섹터 미니 위젯 추가 (평균 변동률 기반 분류)
  * 시장 요약 배너에 지수 데이터 통합 표시
  * 코인 상장 소식 데이터 소스 및 분류 로직 개선

* **Improvements**
  * 뉴스 검색 키워드 매칭 정확도 향상
  * UI 레이블 및 정보 표시 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->