### PR TITLE
fix: 코인 퍼포먼스 개선 + 관심종목·섹터 2열 배치

### DIFF
--- a/src/api/coins.js
+++ b/src/api/coins.js
@@ -110,10 +110,21 @@ export async function fetchCoinPaprika() {
   return await res.json();
 }
 
-// ─── Binance — 전체 USDT 페어 24h 가격 (키 불필요, 매우 빠름) ──
+// ─── Binance — USDT 페어 24h 가격 (키 불필요) ──────────────────
+// 주요 코인만 명시적으로 요청 (전체 1500+ 쌍 → 상위 코인만)
+const BINANCE_SYMBOLS = [
+  'BTC','ETH','SOL','XRP','ADA','DOGE','AVAX','SHIB','DOT','LINK',
+  'UNI','NEAR','APT','ARB','SUI','OP','PEPE','XLM','TON','ATOM',
+  'FIL','ICP','HBAR','ETC','SAND','MANA','INJ','SEI','LTC','BNB',
+  'MATIC','TRX','BCH','AAVE','MKR','RENDER','FET','TAO','WLD','JUP',
+  'ONDO','PENDLE','STX','TIA','PYTH','BONK','WIF','FLOKI','GALA','IMX',
+];
+
 export async function fetchBinancePrices() {
+  // 개별 심볼로 요청 (전체 ticker 대신 ~50개만)
+  const symbols = BINANCE_SYMBOLS.map(s => `"${s}USDT"`).join(',');
   const res = await fetch(
-    'https://api.binance.com/api/v3/ticker/24hr',
+    `https://api.binance.com/api/v3/ticker/24hr?symbols=[${symbols}]`,
     { signal: AbortSignal.timeout(8000) }
   );
   if (!res.ok) throw new Error(`Binance ${res.status}`);
@@ -264,9 +275,8 @@ export async function fetchCoins(krwRate = 1466) {
     }
   }
 
-  // CoinPaprika 실패 → CoinGecko fallback
-  const cgListRaw = await fetchCoinGecko().catch(() => null);
-  const cgList = cgListRaw ?? cgFullCache;
+  // CoinPaprika 실패 → CoinGecko fallback (이미 캐시가 있으면 사용)
+  const cgList = cgFullCache?.length ? cgFullCache : await fetchCoinGecko().catch(() => null);
   if (cgList?.length) {
     const coins = buildFromCoinGecko(cgList, upbitMap, krwRate);
     if (coins.length) {

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -116,7 +116,7 @@ export default function HomeDashboard({
       if (mktCount[item._market] >= 2) continue;
       result.push(item);
       mktCount[item._market]++;
-      if (result.length >= 5) break;
+      if (result.length >= 3) break;
     }
     return result;
   }, [watchedItems.length, allItems]);
@@ -150,14 +150,19 @@ export default function HomeDashboard({
       {/* ─── 경제 이벤트 티커 ─────────────────────────────── */}
       <EventTicker />
 
-      {/* ─── 관심종목 (컴팩트 — 4개 넘으면 스크롤) ──────── */}
-      <WatchlistWidget
-        watchedItems={watchedItems}
-        popularItems={popularItems}
-        toggle={toggle}
-        onItemClick={onItemClick}
-        krwRate={krwRate}
-      />
+      {/* ─── 관심종목 + 섹터 흐름 (2열 나란히, 모바일은 세로) ── */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <WatchlistWidget
+          watchedItems={watchedItems}
+          popularItems={popularItems}
+          toggle={toggle}
+          onItemClick={onItemClick}
+          krwRate={krwRate}
+        />
+        {(krStocks.length > 0 || usStocks.length > 0 || coins.length > 0) && (
+          <SectorMiniWidget krStocks={krStocks} usStocks={usStocks} coins={coins} />
+        )}
+      </div>
 
       {/* ─── 급등/급락 6박스 (첫 화면에 걸치도록 승격) ──── */}
       <TopMoversWidget
@@ -176,11 +181,6 @@ export default function HomeDashboard({
 
       {/* ─── 코인 거래소 공지 ─────────────────────────────── */}
       <CoinListingSection />
-
-      {/* ─── 섹터 로테이션 미니 (HOT 3 + COLD 3 칩 → 섹터 탭 유도) ── */}
-      {(krStocks.length > 0 || usStocks.length > 0 || coins.length > 0) && (
-        <SectorMiniWidget krStocks={krStocks} usStocks={usStocks} coins={coins} />
-      )}
     </div>
   );
 }

--- a/src/hooks/useCoins.js
+++ b/src/hooks/useCoins.js
@@ -67,10 +67,9 @@ export function useCoins(krwRateRef) {
     return () => { clearInterval(quickId); clearInterval(fullId); clearInterval(sparklineId); };
   }, [refreshCoinsQuick, refreshCoins, refreshSparklines]);
 
-  // 최초 로드 시 스파크라인도 가져오기
+  // 최초 로드 시 스파크라인 즉시 가져오기
   useEffect(() => {
-    const timer = setTimeout(refreshSparklines, 3000); // 초기 로드 3초 후
-    return () => clearTimeout(timer);
+    refreshSparklines();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Upbit WebSocket
@@ -100,10 +99,17 @@ export function useCoins(krwRateRef) {
       wsTickBufRef.current[tick.symbol] = tick;
       if (!wsFlushTimer.current) wsFlushTimer.current = setTimeout(flushTicks, 200);
     };
-    subscribeCoinPrices(COINS_INITIAL.map(c => c.symbol), wsHandler);
-    fetchUpbitAllSymbols()
-      .then(symbols => { if (!cancelled) subscribeCoinPrices(symbols, wsHandler); })
-      .catch(() => {});
+    // 전체 심볼 목록으로 한 번만 구독 (이중 구독 방지)
+    const initWs = async () => {
+      try {
+        const symbols = await fetchUpbitAllSymbols();
+        if (!cancelled) subscribeCoinPrices(symbols, wsHandler);
+      } catch {
+        // Upbit 목록 실패 시 초기 심볼로 fallback
+        if (!cancelled) subscribeCoinPrices(COINS_INITIAL.map(c => c.symbol), wsHandler);
+      }
+    };
+    initWs();
     return () => {
       cancelled = true;
       clearTimeout(wsFlushTimer.current);


### PR DESCRIPTION
## Summary

- **코인 퍼포먼스**: Binance 전체 1500+ 쌍 → 50개만 요청 (90% 감소), 초기 스파크라인 3초 딜레이 제거, WS 이중 구독 수정
- **레이아웃**: 관심종목 + 섹터 흐름을 2열 나란히 배치 (데스크탑), 추천 종목 축소, 중복 위젯 제거

## Test plan

- [ ] 코인 탭 초기 로딩 속도 체감 개선 확인
- [ ] 코인 가격 실시간 업데이트 정상 동작
- [ ] 홈 화면에서 관심종목 + 섹터 흐름이 나란히 표시 (데스크탑)
- [ ] 모바일(375px)에서 세로 스택 정상
- [ ] 빈 관심종목 상태에서 추천 3개 표시

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 초기 데이터 로딩 속도 향상으로 앱 시작 시간 단축
  * API 요청 최적화로 보다 효율적인 데이터 조회

* **UI/UX 개선**
  * 홈 대시보드 레이아웃을 반응형 그리드로 재편성
  * 인기 항목 표시 개수 조정으로 더 깔끔한 화면 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->