### PR TITLE
fix: 선행 신호 렌더 연결 + 폴링 상수 추출

### DIFF
--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -9,6 +9,7 @@ import NewsFeedWidget from './widgets/NewsFeedWidget';
 import NotableMoversSection from './NotableMoversSection';
 import MarketInvestorSection from './MarketInvestorSection';
 import EventTicker from './EventTicker';
+import EarlySignalSection from './EarlySignalSection';
 import CoinListingSection from './CoinListingSection';
 
 // ─── 섹터 미니 위젯 (HOT 3 + COLD 3 칩 → 섹터 탭 유도) ──
@@ -149,6 +150,16 @@ export default function HomeDashboard({
 
       {/* ─── 경제 이벤트 티커 ─────────────────────────────── */}
       <EventTicker />
+
+      {/* ─── 선행 신호 (뉴스 발생 + 주가 미반응 종목) ──────── */}
+      {hasData && (
+        <EarlySignalSection
+          allItems={allItems}
+          recentNews={recentNews}
+          krwRate={krwRate}
+          onItemClick={onItemClick}
+        />
+      )}
 
       {/* ─── 관심종목 + 섹터 흐름 (2열 나란히, 모바일은 세로) ── */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/constants/polling.js
+++ b/src/constants/polling.js
@@ -1,0 +1,7 @@
+// 폴링 간격 상수 (밀리초)
+export const POLLING = {
+  FAST:      10_000,   // 10초 — Upbit 빠른 갱신
+  NORMAL:    30_000,   // 30초 — 주식 가격 갱신
+  SLOW:      60_000,   // 60초 — 지수, 코인 전체 갱신
+  SPARKLINE: 300_000,  // 5분  — CoinGecko 스파크라인
+};

--- a/src/hooks/useCoins.js
+++ b/src/hooks/useCoins.js
@@ -6,6 +6,7 @@ import { COINS_INITIAL } from '../data/mock';
 import { fetchCoins, fetchCoinsUpbitOnly, fetchExchangeRate, fetchUpbitAllSymbols, fetchCoinGecko, getSparklineCache } from '../api/coins';
 import { subscribeCoinPrices, unsubscribeCoinPrices } from '../api/coinWs';
 import { setWhaleBtcKrwPrice } from '../api/whale';
+import { POLLING } from '../constants/polling';
 import { checkAndAlertBatch } from '../utils/priceAlert';
 
 export function useCoins(krwRateRef) {
@@ -61,9 +62,9 @@ export function useCoins(krwRateRef) {
 
   // 폴링 인터벌
   useEffect(() => {
-    const quickId     = setInterval(() => refreshCoinsQuick(), 10000);
-    const fullId      = setInterval(refreshCoins, 60000);
-    const sparklineId = setInterval(refreshSparklines, 5 * 60 * 1000); // 5분
+    const quickId     = setInterval(() => refreshCoinsQuick(), POLLING.FAST);
+    const fullId      = setInterval(refreshCoins, POLLING.SLOW);
+    const sparklineId = setInterval(refreshSparklines, POLLING.SPARKLINE);
     return () => { clearInterval(quickId); clearInterval(fullId); clearInterval(sparklineId); };
   }, [refreshCoinsQuick, refreshCoins, refreshSparklines]);
 

--- a/src/hooks/useIndices.js
+++ b/src/hooks/useIndices.js
@@ -1,9 +1,10 @@
-// 지수·환율 폴링 훅 (60초)
+// 지수·환율 폴링 훅
 import { useState, useEffect, useCallback } from 'react';
 import { INDICES_INITIAL } from '../data/mock';
 import { fetchIndices } from '../api/stocks';
 import { fetchExchangeRate } from '../api/coins';
 import { setWhaleKrwRate } from '../api/whale';
+import { POLLING } from '../constants/polling';
 
 export function useIndices() {
   const [indices, setIndices]   = useState(INDICES_INITIAL);
@@ -31,8 +32,8 @@ export function useIndices() {
   useEffect(() => {
     refreshIndices();
     refreshExchangeRate();
-    const indicesId = setInterval(refreshIndices, 60000);
-    const rateId    = setInterval(refreshExchangeRate, 30000);
+    const indicesId = setInterval(refreshIndices, POLLING.SLOW);
+    const rateId    = setInterval(refreshExchangeRate, POLLING.NORMAL);
     return () => { clearInterval(indicesId); clearInterval(rateId); };
   }, [refreshIndices, refreshExchangeRate]);
 

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -1,8 +1,9 @@
-// 미국·국내 주식 가격 폴링 훅 (30초)
+// 미국·국내 주식 가격 폴링 훅
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { KOREAN_STOCKS, US_STOCKS_INITIAL } from '../data/mock';
 import { fetchUsStocksBatch, fetchKoreanStocksBatch } from '../api/stocks';
 import { checkAndAlertBatch } from '../utils/priceAlert';
+import { POLLING } from '../constants/polling';
 
 const US_SYMBOLS = US_STOCKS_INITIAL.map(s => s.symbol);
 
@@ -60,8 +61,8 @@ export function usePrices() {
   useEffect(() => {
     refreshUsStocks();
     refreshKoreanStocks();
-    const usId = setInterval(refreshUsStocks, 30000);
-    const krId = setInterval(refreshKoreanStocks, 30000);
+    const usId = setInterval(refreshUsStocks, POLLING.NORMAL);
+    const krId = setInterval(refreshKoreanStocks, POLLING.NORMAL);
     return () => { clearInterval(usId); clearInterval(krId); };
   }, [refreshUsStocks, refreshKoreanStocks]);
 


### PR DESCRIPTION
## Summary

- **선행 신호 섹션 활성화**: EarlySignalSection이 구현되어 있었으나 렌더 트리에 미연결 → EventTicker 아래에 배치 (장 열린 시간에만 표시)
- **폴링 상수 추출**: 3개 훅의 매직 넘버 → `src/constants/polling.js` 중앙 관리 (FAST 10s, NORMAL 30s, SLOW 60s, SPARKLINE 5m)

## Test plan

- [ ] 장 중: 홈에서 "선행 신호" 섹션 표시 확인 (뉴스 발생 2h 이내 + 주가 미반응 종목)
- [ ] 장 후: 선행 신호 섹션 숨김 확인
- [ ] 코인/주식/지수 폴링 간격 정상 동작 (기능 변경 없음, 상수 참조만 전환)
- [ ] 빌드 정상

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 홈 대시보드에 Early Signal 섹션 추가 - 주요 항목, 최신 뉴스, 환율 정보 조건부 표시

* **개선사항**
  * 데이터 조회 주기 표준화로 시스템 안정성 및 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->