### PR TITLE
fix: NDX 티커 ^IXIC→^NDX 수정 + 지수 갱신 타임스탬프

### DIFF
--- a/api/market-indices.js
+++ b/api/market-indices.js
@@ -7,7 +7,7 @@ export const config = { runtime: 'edge' };
 const INDICES = [
   { id: 'KOSDAQ', symbol: '^KQ11'    },
   { id: 'SPX',    symbol: '^GSPC'    },
-  { id: 'NDX',    symbol: '^IXIC'    },
+  { id: 'NDX',    symbol: '^NDX'     },
   { id: 'DJI',    symbol: '^DJI'     },
   { id: 'DXY',    symbol: 'DX-Y.NYB' },
 ];

--- a/src/api/stocks.js
+++ b/src/api/stocks.js
@@ -369,7 +369,7 @@ const ALL_INDICES = [
   // KOSPI는 Stooq로 별도 처리
   { id: 'KOSDAQ', symbol: '^KQ11'    },
   { id: 'SPX',    symbol: '^GSPC'    },
-  { id: 'NDX',    symbol: '^IXIC'    },
+  { id: 'NDX',    symbol: '^NDX'     },
   { id: 'DJI',    symbol: '^DJI'     },
   { id: 'DXY',    symbol: 'DX-Y.NYB' },
 ];

--- a/src/hooks/useIndices.js
+++ b/src/hooks/useIndices.js
@@ -14,7 +14,11 @@ export function useIndices() {
     try {
       const data = await fetchIndices();
       if (data.length > 0) {
-        setIndices(prev => prev.map(idx => ({ ...idx, ...(data.find(d => d.id === idx.id) ?? {}) })));
+        const now = Date.now();
+        setIndices(prev => prev.map(idx => {
+          const found = data.find(d => d.id === idx.id);
+          return found ? { ...idx, ...found, _lastUpdated: now } : idx;
+        }));
       }
     } catch (e) { console.warn('[지수] 갱신 실패:', e.message); }
   }, []);


### PR DESCRIPTION
## Summary
- NDX에 `^IXIC`(나스닥 종합지수, ~18,000)을 사용하던 것을 `^NDX`(나스닥100, ~21,000)로 수정
- `useIndices` 머지 시 `_lastUpdated` 타임스탬프 추가 — API에서 실제 받은 데이터와 초기 하드코딩값 구분 가능

## Test plan
- [ ] NDX 지수값이 나스닥100 기준(~21,000)으로 정상 표시되는지 확인
- [ ] 6개 지수 모두 changePct가 0이 아닌 실제값 표시 확인

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * NDX 지수가 정확한 데이터 소스에서 가져오도록 수정

* **새로운 기능**
  * 지수의 마지막 업데이트 시간 추적 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->