### PR TITLE
chore: CoinGecko Demo API 키 적용 — rate limit 안정화

### DIFF
--- a/src/api/coins.js
+++ b/src/api/coins.js
@@ -144,6 +144,9 @@ export async function fetchBinancePrices() {
 }
 
 // ─── CoinGecko — 스파크라인 전용 (5분 간격) ────────────────────
+const CG_API_KEY = import.meta.env.VITE_COINGECKO_API_KEY ?? '';
+const CG_HEADERS = CG_API_KEY ? { 'x-cg-demo-api-key': CG_API_KEY } : {};
+
 let cgSparklineCache = {};
 let cgFullCache = [];
 
@@ -157,7 +160,7 @@ export async function fetchCoinGecko() {
     '&sparkline=true',
     '&price_change_percentage=24h',
   ].join('');
-  const res = await fetch(url, { signal: AbortSignal.timeout(15000) });
+  const res = await fetch(url, { headers: CG_HEADERS, signal: AbortSignal.timeout(15000) });
   if (!res.ok) throw new Error(`CoinGecko ${res.status}`);
   const data = await res.json();
   cgFullCache = data;
@@ -219,7 +222,7 @@ export async function fetchExchangeRate() {
     const res = await fetch('https://api.upbit.com/v1/ticker?markets=KRW-BTC', { signal: AbortSignal.timeout(4000) });
     const data = await res.json();
     const btcKrw = data[0]?.trade_price;
-    const cgRes = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd', { signal: AbortSignal.timeout(5000) });
+    const cgRes = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd', { headers: CG_HEADERS, signal: AbortSignal.timeout(5000) });
     const cgData = await cgRes.json();
     const btcUsd = cgData?.bitcoin?.usd;
     if (btcKrw && btcUsd) {


### PR DESCRIPTION
## 변경 내용

CoinGecko 무료 Demo API 키를 적용하여 rate limit 안정화.

-  헤더를 모든 CoinGecko 요청에 추가
- 스파크라인 폴링 + 가격 fallback + 환율 계산 요청 모두 적용
- Vercel 환경변수  등록 완료

---
🤖 Generated by Claude Code [claude-sonnet-4-6]