### PR TITLE
fix: 한투 WS approval_key 자동 재발급 + 백그라운드 탭 폴링 중단

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -95,7 +95,7 @@ export default function App() {
     }
   }, [KR_ETFS, US_ETF_SYMBOLS]);
 
-  useEffect(() => { refreshEtfs(); const id = setInterval(refreshEtfs, 60000); return () => clearInterval(id); }, [refreshEtfs]);
+  useEffect(() => { refreshEtfs(); const id = setInterval(() => { if (!document.hidden) refreshEtfs(); }, 60000); return () => clearInterval(id); }, [refreshEtfs]);
 
   // 전체 갱신
   const refreshAll = useCallback(async () => {

--- a/src/hooks/useCoins.js
+++ b/src/hooks/useCoins.js
@@ -93,12 +93,18 @@ export function useCoins(krwRateRef) {
   useEffect(() => {
     // 마운트 즉시 Upbit REST로 첫 가격 로드 (WS 연결 대기 없이 ~1s 내 실제 가격 표시)
     refreshCoinsQuick();
-    const quickId = setInterval(() => {
-      if (!wsConnectedRef.current) refreshCoinsQuick();
-    }, POLLING.FAST);
-    const fullId      = setInterval(refreshCoins, POLLING.SLOW);
-    const sparklineId = setInterval(refreshSparklines, POLLING.SPARKLINE);
-    return () => { clearInterval(quickId); clearInterval(fullId); clearInterval(sparklineId); };
+    const quickId     = setInterval(() => { if (!document.hidden && !wsConnectedRef.current) refreshCoinsQuick(); }, POLLING.FAST);
+    const fullId      = setInterval(() => { if (!document.hidden) refreshCoins(); }, POLLING.SLOW);
+    const sparklineId = setInterval(() => { if (!document.hidden) refreshSparklines(); }, POLLING.SPARKLINE);
+    // 탭 복귀 시 즉시 갱신
+    const onVisible = () => { if (!document.hidden) refreshCoinsQuick(); };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(quickId);
+      clearInterval(fullId);
+      clearInterval(sparklineId);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [refreshCoinsQuick, refreshCoins, refreshSparklines]);
 
   // 최초 로드 시 스파크라인 즉시 가져오기

--- a/src/hooks/useIndices.js
+++ b/src/hooks/useIndices.js
@@ -36,9 +36,16 @@ export function useIndices() {
   useEffect(() => {
     refreshIndices();
     refreshExchangeRate();
-    const indicesId = setInterval(refreshIndices, POLLING.SLOW);
-    const rateId    = setInterval(refreshExchangeRate, POLLING.NORMAL);
-    return () => { clearInterval(indicesId); clearInterval(rateId); };
+    const indicesId = setInterval(() => { if (!document.hidden) refreshIndices(); }, POLLING.SLOW);
+    const rateId    = setInterval(() => { if (!document.hidden) refreshExchangeRate(); }, POLLING.NORMAL);
+    // 탭 복귀 시 즉시 갱신
+    const onVisible = () => { if (!document.hidden) { refreshIndices(); refreshExchangeRate(); } };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(indicesId);
+      clearInterval(rateId);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [refreshIndices, refreshExchangeRate]);
 
   return { indices, krwRate, refreshIndices };

--- a/src/hooks/useKisUsWebSocket.js
+++ b/src/hooks/useKisUsWebSocket.js
@@ -9,6 +9,7 @@ const TR_ID       = 'HDFSCNT0';
 const MAX_RETRY   = 3;
 const RETRY_DELAY = 5000;
 const MAX_SYMS    = 40;
+const KEY_TTL_MS  = 23 * 60 * 60 * 1000; // 23h — 한투 approval_key 24h 만료 1h 전 자동 갱신
 
 // 거래소 코드 매핑 (KIS HDFSCNT0 기준)
 // NASD: NASDAQ, NYSE: New York Stock Exchange
@@ -83,14 +84,15 @@ function parseSymbol(trKey) {
  * @param {Function} onQuote  - 콜백: ({ symbol, price, change, changePct }) => void
  */
 export function useKisUsWebSocket(symbols, onQuote) {
-  const onQuoteRef     = useRef(onQuote);
-  const symbolsRef     = useRef(symbols);
-  const prevSymbolsRef = useRef([]);
-  const wsRef          = useRef(null);
-  const approvalKeyRef = useRef(null);
-  const retryRef       = useRef(0);
-  const retryTimer     = useRef(null);
-  const mountedRef     = useRef(true);
+  const onQuoteRef      = useRef(onQuote);
+  const symbolsRef      = useRef(symbols);
+  const prevSymbolsRef  = useRef([]);
+  const wsRef           = useRef(null);
+  const approvalKeyRef  = useRef(null);
+  const retryRef        = useRef(0);
+  const retryTimer      = useRef(null);
+  const keyRefreshTimer = useRef(null);
+  const mountedRef      = useRef(true);
 
   useEffect(() => { onQuoteRef.current = onQuote; }, [onQuote]);
   useEffect(() => { symbolsRef.current = symbols; }, [symbols]);
@@ -229,15 +231,36 @@ export function useKisUsWebSocket(symbols, onQuote) {
       };
     }
 
+    // approval_key 갱신 + WS 재연결 (23시간마다 자동 실행)
+    function scheduleKeyRefresh() {
+      clearTimeout(keyRefreshTimer.current);
+      keyRefreshTimer.current = setTimeout(async () => {
+        if (!mountedRef.current) return;
+        const newKey = await fetchApprovalKey();
+        if (!mountedRef.current || !newKey) return;
+        approvalKeyRef.current = newKey;
+        // 기존 WS 정리 후 새 키로 재연결
+        clearTimeout(retryTimer.current);
+        const oldWs = wsRef.current;
+        if (oldWs) { oldWs.onclose = null; oldWs.close(); wsRef.current = null; }
+        retryRef.current = 0;
+        prevSymbolsRef.current = [];
+        connect(newKey);
+        scheduleKeyRefresh(); // 다음 갱신 예약
+      }, KEY_TTL_MS);
+    }
+
     fetchApprovalKey().then(key => {
       if (!mountedRef.current || !key) return;
       approvalKeyRef.current = key;
       connect(key);
+      scheduleKeyRefresh();
     });
 
     return () => {
       mountedRef.current = false;
       clearTimeout(retryTimer.current);
+      clearTimeout(keyRefreshTimer.current);
       const ws  = wsRef.current;
       const key = approvalKeyRef.current;
       if (ws) {

--- a/src/hooks/useKisWebSocket.js
+++ b/src/hooks/useKisWebSocket.js
@@ -5,10 +5,11 @@
 
 import { useEffect, useRef } from 'react';
 
-const KIS_WS_URL = 'wss://ops.koreainvestment.com:21000';
-const TR_ID      = 'H0STCNT0';
-const MAX_RETRY  = 3;      // 최대 재연결 횟수
-const RETRY_DELAY_MS = 5000; // 재연결 대기 시간 (5초)
+const KIS_WS_URL     = 'wss://ops.koreainvestment.com:21000';
+const TR_ID          = 'H0STCNT0';
+const MAX_RETRY      = 3;
+const RETRY_DELAY_MS = 5000;
+const KEY_TTL_MS     = 23 * 60 * 60 * 1000; // 23h — 한투 approval_key 24h 만료 1h 전 자동 갱신
 
 /**
  * KIS WebSocket 실시간 체결 가격 구독 훅
@@ -17,12 +18,13 @@ const RETRY_DELAY_MS = 5000; // 재연결 대기 시간 (5초)
  */
 export function useKisWebSocket(symbols, onQuote) {
   // 최신 콜백·symbols을 ref로 유지 → 재연결 시 클로저 문제 방지
-  const onQuoteRef  = useRef(onQuote);
-  const symbolsRef  = useRef(symbols);
-  const wsRef       = useRef(null);
-  const retryRef    = useRef(0);
-  const retryTimer  = useRef(null);
-  const mountedRef  = useRef(true);
+  const onQuoteRef      = useRef(onQuote);
+  const symbolsRef      = useRef(symbols);
+  const wsRef           = useRef(null);
+  const retryRef        = useRef(0);
+  const retryTimer      = useRef(null);
+  const keyRefreshTimer = useRef(null);
+  const mountedRef      = useRef(true);
 
   // 콜백·symbols 최신값 동기화 (재연결 없이)
   useEffect(() => { onQuoteRef.current = onQuote; }, [onQuote]);
@@ -165,21 +167,40 @@ export function useKisWebSocket(symbols, onQuote) {
       };
     }
 
+    // approval_key 갱신 + WS 재연결 (23시간마다 자동 실행)
+    function scheduleKeyRefresh() {
+      clearTimeout(keyRefreshTimer.current);
+      keyRefreshTimer.current = setTimeout(async () => {
+        if (!mountedRef.current) return;
+        const newKey = await fetchApprovalKey();
+        if (!mountedRef.current || !newKey) return;
+        approvalKey = newKey;
+        clearTimeout(retryTimer.current);
+        const oldWs = wsRef.current;
+        if (oldWs) { oldWs.onclose = null; oldWs.close(); wsRef.current = null; }
+        retryRef.current = 0;
+        connect(newKey);
+        scheduleKeyRefresh();
+      }, KEY_TTL_MS);
+    }
+
     // ── 초기 실행: approval_key 취득 후 연결 ─────────────────
     fetchApprovalKey().then(key => {
       if (!mountedRef.current || !key) return;
       approvalKey = key;
       connect(key);
+      scheduleKeyRefresh();
     });
 
     // ── 클린업: 구독 해제 + 소켓 닫기 ───────────────────────
     return () => {
       mountedRef.current = false;
       clearTimeout(retryTimer.current);
+      clearTimeout(keyRefreshTimer.current);
       const ws = wsRef.current;
       if (ws) {
         if (approvalKey) unsubscribe(ws, approvalKey, symbolsRef.current);
-        ws.onclose = null; // 클린업 시 재연결 루프 방지
+        ws.onclose = null;
         ws.close();
         wsRef.current = null;
       }

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -108,9 +108,16 @@ export function usePrices() {
   useEffect(() => {
     refreshUsStocks();
     refreshKoreanStocks();
-    const usId = setInterval(refreshUsStocks, POLLING.NORMAL);
-    const krId = setInterval(refreshKoreanStocks, POLLING.NORMAL);
-    return () => { clearInterval(usId); clearInterval(krId); };
+    const usId = setInterval(() => { if (!document.hidden) refreshUsStocks(); }, POLLING.NORMAL);
+    const krId = setInterval(() => { if (!document.hidden) refreshKoreanStocks(); }, POLLING.NORMAL);
+    // 탭 복귀 시 즉시 갱신
+    const onVisible = () => { if (!document.hidden) { refreshUsStocks(); refreshKoreanStocks(); } };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(usId);
+      clearInterval(krId);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [refreshUsStocks, refreshKoreanStocks]);
 
   return {


### PR DESCRIPTION
## 변경 내용

Closes #122

### P0-NEW-1: 한투 WS approval_key 23시간 자동 재발급
KIS approval_key는 24시간 만료됩니다. 기존 코드는 재발급 로직이 없어 하루 1회 국장/미장 실시간 WebSocket이 조용히 죽었습니다.

- `useKisWebSocket`, `useKisUsWebSocket` 양쪽에 `scheduleKeyRefresh()` 추가
- `KEY_TTL_MS = 23h` 타이머로 만료 1시간 전 자동 재발급
- 새 키 발급 후 기존 WS 닫고 즉시 재연결 + 구독 복원
- cleanup 시 타이머 함께 제거

### P0-NEW-2: Page Visibility API — 백그라운드 탭 폴링 스킵
탭 비활성 시에도 인터벌 6개가 계속 동작하며 API quota를 소모했습니다.

- `useCoins`, `usePrices`, `useIndices`, `App.jsx` 모든 인터벌에 `document.hidden` 체크 추가
- `visibilitychange` 리스너로 탭 복귀 시 즉시 갱신

## Test plan

- [ ] 국장/미장 WS 연결 후 23시간 경과 시 자동 재연결 로그 확인
- [ ] 탭 백그라운드 전환 후 Network 탭에서 폴링 요청 없음 확인
- [ ] 탭 복귀 시 즉시 가격 갱신 확인

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 브라우저 탭이 숨겨진 상태일 때 불필요한 데이터 업데이트를 중단하여 배경 작업 최적화
  * 탭이 다시 보이면 즉시 데이터를 새로고침

* **버그 수정**
  * API 키를 주기적으로 자동 갱신(23시간 주기)하여 WebSocket 연결 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->