### PR TITLE
fix: 홈 섹터 위젯 '상세' 버튼 → 섹터 탭 이동 연결 (#126)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -197,6 +197,7 @@ export default function App() {
               indices={indices} krStocks={krStocks} usStocks={usStocks}
               coins={coins} etfs={mergedEtfs} krwRate={krwRate}
               onItemClick={setSelectedItem} onNewsClick={setSelectedNews}
+              onTabChange={setActiveTab}
             />
           ) : activeTab === 'sector' ? (
             <SectorRotation krStocks={krStocks} usStocks={usStocks} coins={coins} />

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -12,7 +12,7 @@ import EventTicker from './EventTicker';
 import CoinListingSection from './CoinListingSection';
 
 // ─── 섹터 미니 위젯 (HOT 3 + COLD 3 칩 → 섹터 탭 유도) ──
-function SectorMiniWidget({ krStocks, usStocks, coins }) {
+function SectorMiniWidget({ krStocks, usStocks, coins, onTabChange }) {
   const sectors = useMemo(() => {
     const coinsWithPct = coins.filter(c => c.sector).map(c => ({ ...c, changePct: c.change24h ?? 0 }));
     const items = [...krStocks, ...usStocks, ...coinsWithPct];
@@ -40,7 +40,10 @@ function SectorMiniWidget({ krStocks, usStocks, coins }) {
           <span className="text-[13px] font-bold text-[#191F28]">섹터 자금 흐름</span>
           <span className="text-[10px] text-[#B0B8C1]">HOT · COLD</span>
         </div>
-        <span className="text-[11px] text-[#3182F6] font-medium">섹터 탭에서 상세 →</span>
+        <button
+          onClick={() => onTabChange?.('sector')}
+          className="text-[11px] text-[#3182F6] font-medium hover:underline"
+        >섹터 탭에서 상세 →</button>
       </div>
       <div className="flex gap-4">
         {/* HOT */}
@@ -72,7 +75,7 @@ function SectorMiniWidget({ krStocks, usStocks, coins }) {
 
 export default function HomeDashboard({
   indices = [], krStocks = [], usStocks = [], coins = [], etfs = [],
-  krwRate = 1466, onItemClick, onNewsClick,
+  krwRate = 1466, onItemClick, onNewsClick, onTabChange,
 }) {
   const { data: allNews = [] } = useAllNewsQuery();
   const { watchlist, toggle, isWatched } = useWatchlist();
@@ -161,7 +164,7 @@ export default function HomeDashboard({
           krwRate={krwRate}
         />
         {(krStocks.length > 0 || usStocks.length > 0 || coins.length > 0) && (
-          <SectorMiniWidget krStocks={krStocks} usStocks={usStocks} coins={coins} />
+          <SectorMiniWidget krStocks={krStocks} usStocks={usStocks} coins={coins} onTabChange={onTabChange} />
         )}
       </div>
 


### PR DESCRIPTION
## 변경 내용
홈 화면 '섹터 자금 흐름' 위젯의 '섹터 탭에서 상세 →' 클릭 시 섹터 탭으로 이동하지 않던 버그 수정.

**원인**: `<span>` 요소로 구현되어 클릭 핸들러 없음 + `onTabChange` prop 미전달

**수정**:
- `App.jsx`: `HomeDashboard`에 `onTabChange={setActiveTab}` 추가
- `home/index.jsx`: `SectorMiniWidget`까지 `onTabChange` prop 체인 연결
- `<span>` → `<button onClick={() => onTabChange?.('sector')}>` 교체

Closes #126

---
🤖 Generated by Claude Code [claude-sonnet-4-6]