### PR TITLE
feat: 경제 이벤트 캘린더 위젯 홈 연결

### DIFF
--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -10,6 +10,7 @@ import NotableMoversSection from './NotableMoversSection';
 import MarketInvestorSection from './MarketInvestorSection';
 import EarlySignalSection from './EarlySignalSection';
 import EventTicker from './EventTicker';
+import EventCalendar from './EventCalendar';
 import CoinListingSection from './CoinListingSection';
 
 // ─── 섹터 미니 위젯 (HOT 3 + COLD 3 칩 → 섹터 탭 유도) ──
@@ -153,6 +154,9 @@ export default function HomeDashboard({
 
       {/* ─── 경제 이벤트 티커 ─────────────────────────────── */}
       <EventTicker />
+
+      {/* ─── 경제 이벤트 캘린더 (이번 주/다음 주) ─────────── */}
+      <EventCalendar />
 
 
       {/* ─── 관심종목 + 섹터 흐름 (2열 나란히, 모바일은 세로) ── */}


### PR DESCRIPTION
## 변경 내용

홈 대시보드에 **경제 이벤트 캘린더** 위젯 연결.

- FOMC, CPI, NFP, PCE, GDP, 금통위 등 2026년 주요 경제 이벤트 표시
- 이번 주/다음 주 이벤트 타임라인 카드
- 이벤트 없으면 섹션 자동 숨김
- EventTicker(롤링 스트립) 아래 전체 뷰 제공

Closes #131

---
🤖 Generated by Claude Code [claude-sonnet-4-6]