### PR TITLE
fix: 관련뉴스 오염 차단 강화 + Vercel PR 프리뷰 빌드 비활성화

### DIFF
--- a/src/components/NewsSidePanel.jsx
+++ b/src/components/NewsSidePanel.jsx
@@ -72,8 +72,8 @@ const STOPWORDS = new Set([
   'rise','rises','rising','fall','falls','falling','high','low','record','billion','million',
   'percent','pct','stock','stocks','share','shares','crypto','economy','economic','financial',
   'finance','global','world','us','uk',
-  // 한국어 조사/접속어/보조어
-  '위해','대한','통해','따른','관련','이번','올해','내년','지난','오늘','어제','내일',
+  // 한국어 조사/접속어/보조어 (내용어 아닌 연결어 전수 추가)
+  '위해','위한','통한','대한','통해','따른','관련','이번','올해','내년','지난','오늘','어제','내일',
   '것으로','있는','하는','되는','된다','한다','있다','없다','것이','라고','에서','까지',
   '부터','으로','에게','한편','또한','이에','따라','대해','보도','전했다','밝혔다',
   '알려졌다','나타났다','분석했다','전망했다','보였다','기자',
@@ -192,9 +192,8 @@ export default function NewsSidePanel({ news, allData, krwRate, onClose, onRelat
     // score Map: symbol → { item, score }
     const scored = new Map();
 
-    // Stage 1: 키워드 직접 매칭 (score 10)
+    // Stage 1: 키워드 직접 매칭 (score 10) — 직접 언급 종목은 시장 제한 없이 표시
     for (const item of all) {
-      if (!allowedMarkets.has(item._market)) continue;
       const keywords = buildStockKeywords(item.symbol, item.name,
         item._market === 'KR' ? 'KR' : item._market === 'COIN' ? 'COIN' : 'US');
       if (keywords.length > 0 && matchesKeywords(text, keywords)) {

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,6 @@
   "framework": "vite",
   "rewrites": [
     { "source": "/((?!api/).*)", "destination": "/index.html" }
-  ]
+  ],
+  "ignoreCommand": "[ \"$VERCEL_ENV\" != \"production\" ]"
 }


### PR DESCRIPTION
## 변경 사항

Closes #155

### 1. STOPWORDS '위한', '통한' 추가
- 한국어 연결어가 키워드로 채점되어 `채택(1pt) + 위한(1pt) + 위험(1pt) = 3pt` → 동일 카테고리 임계값 통과
- XRP 기사에 OpenAI 뉴스가 관련뉴스로 나오는 근본 원인 제거

### 2. Stage 1 allowedMarkets 필터 제거
- 기존 코드에서 Stage 1(직접 매칭)에도 시장 필터가 적용되어 `kr` 카테고리 XRP 기사에서 XRP 코인이 관련 종목에 아예 미노출 (회귀)
- 직접 언급된 종목은 시장 구분 없이 항상 표시, 필터는 Stage 2·3(확장)에만 적용

### 3. vercel.json ignoreCommand
- PR 브랜치마다 Vercel preview 빌드가 생성되어 100/day 한도 소진
- `ignoreCommand: [ "$VERCEL_ENV" != "production" ]` → production(main) 배포만 실행

---
🤖 Generated by Claude Code [claude-sonnet-4-6]