### PR TITLE
feat: Fear & Greed 지수 위젯 (P2-8)

### DIFF
--- a/api/fear-greed.js
+++ b/api/fear-greed.js
@@ -1,0 +1,41 @@
+// api/fear-greed.js — CNN Money Fear & Greed 지수 프록시 (Edge Function)
+// 클라이언트에서 직접 호출 시 CORS 차단 → 서버사이드 프록시 경유
+export const config = { runtime: 'edge' };
+
+const CNN_URL = 'https://production.dataviz.cnn.io/index/fearandgreed/graphdata';
+
+export default async function handler() {
+  try {
+    const res = await fetch(CNN_URL, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible)',
+        'Accept': 'application/json',
+        'Referer': 'https://edition.cnn.com/',
+      },
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!res.ok) throw new Error(`CNN F&G ${res.status}`);
+
+    const data = await res.json();
+    const fg = data?.fear_and_greed;
+    if (fg?.score == null) throw new Error('no score');
+
+    return new Response(JSON.stringify({
+      score: Math.round(fg.score),
+      rating: fg.rating ?? '',
+      previousClose: fg.previous_close ?? null,
+      previousWeek: fg.previous_1_week ?? null,
+    }), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, s-maxage=300',
+      },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -6,6 +6,7 @@ import MarketPulseWidget from './widgets/MarketPulseWidget';
 import WatchlistWidget from './widgets/WatchlistWidget';
 import TopMoversWidget from './widgets/TopMoversWidget';
 import NewsFeedWidget from './widgets/NewsFeedWidget';
+import FearGreedWidget from './widgets/FearGreedWidget';
 import NotableMoversSection from './NotableMoversSection';
 import MarketInvestorSection from './MarketInvestorSection';
 import EarlySignalSection from './EarlySignalSection';
@@ -151,7 +152,8 @@ export default function HomeDashboard({
         />
       )}
 
-      {/* ─── 경제 이벤트 티커 ─────────────────────────────── */}
+      {/* ─── 공포탐욕 지수 + 경제 이벤트 티커 ─────────────── */}
+      <FearGreedWidget />
       <EventTicker />
 
       {/* ─── 관심종목 + 섹터 흐름 (2열 나란히, 모바일은 세로) ── */}

--- a/src/components/home/widgets/FearGreedWidget.jsx
+++ b/src/components/home/widgets/FearGreedWidget.jsx
@@ -1,0 +1,90 @@
+// Fear & Greed 지수 위젯 — 코인(Alternative.me) + 미장(CNN Money)
+// Market Pulse 영역 하단에 표시
+import { useFearGreed, getFgLabel, getFgColor } from '../../../hooks/useFearGreed';
+
+function FgGauge({ score, label, color }) {
+  const pct = Math.min(100, Math.max(0, score ?? 0));
+  return (
+    <div className="flex items-center gap-2.5 min-w-0">
+      {/* 아크 게이지 대신 심플한 수평 바 */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-[22px] font-bold tabular-nums font-mono leading-none" style={{ color }}>
+            {score ?? '—'}
+          </span>
+          <span className="text-[11px] font-bold px-1.5 py-0.5 rounded-full" style={{ background: `${color}18`, color }}>
+            {label}
+          </span>
+        </div>
+        <div className="h-1.5 bg-[#F2F4F6] rounded-full overflow-hidden">
+          {/* 점수 위치에 인디케이터 */}
+          <div
+            className="h-full rounded-full transition-all duration-700"
+            style={{
+              width: `${pct}%`,
+              background: `linear-gradient(90deg, #F04452 0%, #FF6B35 25%, #8B95A1 50%, #2AC769 75%, #00B894 100%)`,
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FgSkeleton() {
+  return <div className="h-8 w-20 bg-[#F2F4F6] rounded-lg animate-pulse" />;
+}
+
+export default function FearGreedWidget() {
+  const { crypto, us } = useFearGreed();
+
+  const cryptoScore  = crypto.data?.score;
+  const cryptoLabel  = getFgLabel(cryptoScore);
+  const cryptoColor  = getFgColor(cryptoScore);
+
+  const usScore  = us.data?.score;
+  const usLabel  = getFgLabel(usScore);
+  const usColor  = getFgColor(usScore);
+
+  // 둘 다 로딩 실패 시 숨김
+  if (crypto.isError && us.isError) return null;
+
+  return (
+    <div className="bg-white rounded-2xl border border-[#F2F4F6] shadow-sm p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-[13px] font-bold text-[#191F28]">공포 &amp; 탐욕 지수</span>
+        <span className="text-[10px] text-[#B0B8C1]">Fear &amp; Greed Index</span>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {/* 코인 */}
+        <div>
+          <div className="flex items-center gap-1 mb-2">
+            <span className="text-[10px] font-bold text-[#8B95A1] uppercase tracking-wide">🪙 코인</span>
+            <span className="text-[9px] text-[#C9CDD2]">Alternative.me</span>
+          </div>
+          {crypto.isLoading ? <FgSkeleton /> : (
+            crypto.isError ? (
+              <span className="text-[11px] text-[#B0B8C1]">불러오기 실패</span>
+            ) : (
+              <FgGauge score={cryptoScore} label={cryptoLabel} color={cryptoColor} />
+            )
+          )}
+        </div>
+        {/* 미장 */}
+        <div>
+          <div className="flex items-center gap-1 mb-2">
+            <span className="text-[10px] font-bold text-[#8B95A1] uppercase tracking-wide">🇺🇸 미장</span>
+            <span className="text-[9px] text-[#C9CDD2]">CNN Money</span>
+          </div>
+          {us.isLoading ? <FgSkeleton /> : (
+            us.isError ? (
+              <span className="text-[11px] text-[#B0B8C1]">불러오기 실패</span>
+            ) : (
+              <FgGauge score={usScore} label={usLabel} color={usColor} />
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useFearGreed.js
+++ b/src/hooks/useFearGreed.js
@@ -1,0 +1,65 @@
+// 공포탐욕지수 훅 — 코인(Alternative.me) + 미장(CNN Money 프록시)
+// Alternative.me: CORS 지원, 직접 호출 가능
+// CNN Money: CORS 차단 → /api/fear-greed 프록시 경유
+import { useQuery } from '@tanstack/react-query';
+
+// 점수 → 레이블 매핑
+export function getFgLabel(score) {
+  if (score == null) return '';
+  if (score <= 24)  return '극단적 공포';
+  if (score <= 44)  return '공포';
+  if (score <= 55)  return '중립';
+  if (score <= 74)  return '탐욕';
+  return '극단적 탐욕';
+}
+
+// 점수 → 색상
+export function getFgColor(score) {
+  if (score == null) return '#8B95A1';
+  if (score <= 24)  return '#F04452';  // 극단적 공포 — 빨강
+  if (score <= 44)  return '#FF6B35';  // 공포 — 주황
+  if (score <= 55)  return '#8B95A1';  // 중립 — 회색
+  if (score <= 74)  return '#2AC769';  // 탐욕 — 녹색
+  return '#00B894';                    // 극단적 탐욕 — 진녹색
+}
+
+async function fetchCryptoFG() {
+  const res = await fetch('https://api.alternative.me/fng/', {
+    signal: AbortSignal.timeout(6000),
+  });
+  if (!res.ok) throw new Error(`Alternative.me ${res.status}`);
+  const data = await res.json();
+  const entry = data?.data?.[0];
+  return {
+    score: Number(entry?.value ?? 0),
+    rating: entry?.value_classification ?? '',
+  };
+}
+
+async function fetchUsFG() {
+  const res = await fetch('/api/fear-greed', {
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!res.ok) throw new Error(`CNN F&G ${res.status}`);
+  return res.json();
+}
+
+export function useFearGreed() {
+  const crypto = useQuery({
+    queryKey: ['fearGreed', 'crypto'],
+    queryFn: fetchCryptoFG,
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: 10 * 60 * 1000,
+    retry: 1,
+  });
+
+  const us = useQuery({
+    queryKey: ['fearGreed', 'us'],
+    queryFn: fetchUsFG,
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: 10 * 60 * 1000,
+    retry: 1,
+  });
+
+  return { crypto, us };
+}


### PR DESCRIPTION
## 변경 내용

코인(Alternative.me) + 미장(CNN Money) Fear & Greed 지수를 홈 대시보드에 통합 표시.

### 구현 방식
- `api/fear-greed.js` — CNN Money F&G API 프록시 (Edge Function, CORS 우회, 5분 캐시)
- `src/hooks/useFearGreed.js` — Alternative.me 직접 + /api/fear-greed 프록시 React Query 훅
- `src/components/home/widgets/FearGreedWidget.jsx` — 점수 + 레이블 + 색상 바 게이지
- `src/components/home/index.jsx` — FearGreedWidget 삽입 (EventTicker 위)

### UI 동작
- 점수 범위: 0–24 극단적 공포(빨강) / 25–44 공포(주황) / 45–55 중립(회색) / 56–74 탐욕(녹색) / 75–100 극단적 탐욕(진녹색)
- 개별 API 실패 시 해당 칸만 '불러오기 실패' 표시
- 둘 다 실패 시 위젯 전체 숨김

### 변경 파일
- `api/fear-greed.js` — 신규
- `src/hooks/useFearGreed.js` — 신규
- `src/components/home/widgets/FearGreedWidget.jsx` — 신규
- `src/components/home/index.jsx` — FearGreedWidget import + 렌더링 추가

Closes #159

---
🤖 Generated by Claude Code [claude-sonnet-4-6]