### PR TITLE
feat: 다크모드 수동 토글 + CSS 토큰 커버리지 확장

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import { fetchKoreanStocksBatch, fetchEtfPricesBatch } from './api/stocks';
 import { requestNotificationPermission, getNotificationPermission, setAlertWatchlistIds } from './utils/priceAlert';
 import { useWatchlist } from './hooks/useWatchlist';
 import { useNewsAlerts } from './hooks/useNewsAlerts';
+import { useDarkMode } from './hooks/useDarkMode';
 import { useKrxEtf } from './hooks/useKrxEtf';
 import { useKisWebSocket } from './hooks/useKisWebSocket';
 import { useKisUsWebSocket } from './hooks/useKisUsWebSocket';
@@ -26,6 +27,7 @@ import { useIndices } from './hooks/useIndices';
 import { KOREAN_STOCKS } from './data/mock';
 
 export default function App() {
+  const { dark, toggle: toggleDark } = useDarkMode();
   const { watchlist, krSymbols, usSymbols } = useWatchlist();
   const { indices, krwRate }        = useIndices();
   const krwRateRef                  = useRef(1466);
@@ -262,6 +264,7 @@ export default function App() {
         krwRate={krwRate} lastUpdated={lastUpdated} onRefresh={refreshAll} loading={loading}
         activeTab={activeTab} onTabChange={setActiveTab}
         krStocks={krStocks} usStocks={usStocks} coins={coins}
+        dark={dark} onDarkToggle={toggleDark}
       />
 
       <div className="max-w-[1440px] mx-auto grid grid-cols-1 lg:grid-cols-[1fr_360px]">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,23 @@
-// 데스크탑 헤더 — 탭 + 장 상태 + 환율 + 새로고침
+// 데스크탑 헤더 — 탭 + 장 상태 + 환율 + 새로고침 + 다크모드 토글
 // 탭: active 상태 개선 (underline + filled bg), 뱃지 🔥, 이모지 레이블
 import { getKoreanMarketStatus, getUsMarketStatus } from '../utils/marketHours';
 import { fmt } from '../utils/format';
 import { Button } from '@coinbase/cds-web/buttons';
+
+function DarkToggleIcon({ dark }) {
+  return dark ? (
+    // 해 아이콘 (라이트로 전환)
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="4"/>
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
+    </svg>
+  ) : (
+    // 달 아이콘 (다크로 전환)
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+  );
+}
 
 const TABS = [
   { id: 'home', label: '🏠 홈' },
@@ -32,6 +47,7 @@ function getTabHasSurge(id, { krStocks, usStocks, coins }) {
 export default function Header({
   krwRate, lastUpdated, onRefresh, loading, activeTab, onTabChange,
   krStocks = [], usStocks = [], coins = [],
+  dark = false, onDarkToggle,
 }) {
   const kr = getKoreanMarketStatus();
   const us = getUsMarketStatus();
@@ -112,6 +128,17 @@ export default function Header({
               <span className="w-1.5 h-1.5 rounded-full bg-[#2AC769] animate-pulse" />
               <span className="text-[12px] text-[#B0B8C1] font-mono">{timeStr}</span>
             </div>
+          )}
+
+          {/* 다크모드 토글 */}
+          {onDarkToggle && (
+            <button
+              onClick={onDarkToggle}
+              title={dark ? '라이트 모드로 전환' : '다크 모드로 전환'}
+              className="flex items-center justify-center w-8 h-8 rounded-lg text-[#6B7684] hover:bg-[#F2F4F6] hover:text-[#191F28] transition-colors"
+            >
+              <DarkToggleIcon dark={dark} />
+            </button>
           )}
 
           {/* 새로고침 버튼 */}

--- a/src/hooks/useDarkMode.js
+++ b/src/hooks/useDarkMode.js
@@ -1,0 +1,41 @@
+// 다크모드 훅 — localStorage 저장 + 시스템 선호도 자동 감지
+// html.dark 클래스를 직접 제어 → tokens.css의 html.dark 오버라이드 적용
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'mr_darkMode';
+
+function getInitial() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved !== null) return saved === 'true';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  } catch {
+    return false;
+  }
+}
+
+export function useDarkMode() {
+  const [dark, setDark] = useState(getInitial);
+
+  // html.dark 클래스 토글 + localStorage 저장
+  useEffect(() => {
+    const root = document.documentElement;
+    if (dark) root.classList.add('dark');
+    else root.classList.remove('dark');
+    try { localStorage.setItem(STORAGE_KEY, String(dark)); } catch {}
+  }, [dark]);
+
+  // 수동 설정 없을 때만 시스템 선호도 변경 감지
+  useEffect(() => {
+    const hasSaved = localStorage.getItem(STORAGE_KEY) !== null;
+    if (hasSaved) return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e) => setDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  const toggle = () => setDark(d => !d);
+
+  return { dark, toggle };
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -62,11 +62,14 @@
   --radius-pill: 9999px;
 }
 
-/* ── 다크모드 토큰 오버라이드 ─────────────────────────────────
+/* ── 다크모드 CSS 변수 (공통) ─────────────────────────────────
    상승/하락 색상 (ADR-002 한국 컨벤션 유지, WCAG AA 검증 완료):
    - 상승 #F04452 → #FF6B77 (6.74:1 on dark bg)
    - 하락 #1764ED → #5B9CF6 (6.66:1 on dark bg)
+   적용 방법: 시스템 선호도(@media) + 수동 토글(html.dark) 모두 지원
 ──────────────────────────────────────────────────────────── */
+
+/* ── 시스템 선호도 다크모드 ─────────────────────────────────── */
 @media (prefers-color-scheme: dark) {
   :root {
     --fg:           #E8EBF0;
@@ -75,6 +78,9 @@
     --fg-inverse:   #191F28;
     --fg-positive:  #FF6B77;
     --fg-negative:  #5B9CF6;
+    --fg-neutral:   #6B7684;
+    --fg-warning:   #FFAA33;
+    --fg-live:      #3DD68C;
     --bg-positive:  rgba(255,107,119,0.12);
     --bg-negative:  rgba(91,156,246,0.12);
     --bg-warning:   rgba(255,149,0,0.12);
@@ -84,51 +90,115 @@
     --bg-hover:     #252A35;
     --border:       #2A2F3C;
     --border-heavy: #3A4050;
+    --primary:      #4E9BFF;
+    --primary-muted: rgba(78,155,255,0.12);
+    --live:         #3DD68C;
     --elevation-1:  0 2px 8px rgba(0,0,0,0.4);
     --elevation-2:  0 8px 24px rgba(0,0,0,0.6);
   }
+}
 
-  body {
-    background: var(--bg) !important;
-    color: var(--fg);
-  }
+/* ── 다크모드 유틸리티 오버라이드 (미디어쿼리 + html.dark 모두 적용) ── */
+@media (prefers-color-scheme: dark) { body { background: var(--bg) !important; color: var(--fg); } }
+html.dark body { background: var(--bg) !important; color: var(--fg); }
 
+/* 수동 토글(html.dark)에서 :root 변수 오버라이드 */
+html.dark {
+  --fg:           #E8EBF0;
+  --fg-muted:     #8B95A1;
+  --fg-disabled:  #4A525C;
+  --fg-inverse:   #191F28;
+  --fg-positive:  #FF6B77;
+  --fg-negative:  #5B9CF6;
+  --fg-neutral:   #6B7684;
+  --fg-warning:   #FFAA33;
+  --fg-live:      #3DD68C;
+  --bg-positive:  rgba(255,107,119,0.12);
+  --bg-negative:  rgba(91,156,246,0.12);
+  --bg-warning:   rgba(255,149,0,0.12);
+  --bg:           #0F1117;
+  --bg-surface:   #1A1D24;
+  --bg-alt:       #1F2330;
+  --bg-hover:     #252A35;
+  --border:       #2A2F3C;
+  --border-heavy: #3A4050;
+  --primary:      #4E9BFF;
+  --primary-muted: rgba(78,155,255,0.12);
+  --live:         #3DD68C;
+  --elevation-1:  0 2px 8px rgba(0,0,0,0.4);
+  --elevation-2:  0 8px 24px rgba(0,0,0,0.6);
+}
+
+/* color-scheme 힌트 — 스크롤바/인풋 등 브라우저 기본 UI에 다크 테마 적용 */
+@media (prefers-color-scheme: dark) { :root { color-scheme: dark; } }
+html.dark { color-scheme: dark; }
+
+/* ─── 시스템 다크 오버라이드 ─────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
   .bg-white, [class*="bg-white"] { background-color: var(--bg-surface) !important; }
-
-  .bg-\[\#F8F9FA\], .bg-\[\#F2F4F6\], .bg-\[\#FAFBFC\], .bg-\[\#F7F8FA\] {
-    background-color: var(--bg-alt) !important;
-  }
-
-  header.bg-white {
-    background-color: var(--bg-surface) !important;
-    border-bottom-color: var(--border) !important;
-  }
-
-  nav.bg-white {
-    background-color: var(--bg-surface) !important;
-    border-top-color: var(--border) !important;
-  }
-
-  .border-\[\#E5E8EB\], .border-\[\#F2F4F6\] { border-color: var(--border) !important; }
+  .bg-\[\#F8F9FA\], .bg-\[\#F2F4F6\], .bg-\[\#FAFBFC\], .bg-\[\#F7F8FA\] { background-color: var(--bg-alt) !important; }
+  .bg-\[\#FFF0F1\], .bg-\[\#FFF0F0\], .bg-\[\#FFD6D9\], .bg-\[\#FFD0D4\] { background-color: var(--bg-positive) !important; }
+  .bg-\[\#EDF4FF\], .bg-\[\#F4F8FF\], .bg-\[\#F0F4FF\] { background-color: var(--bg-negative) !important; }
+  .bg-\[\#FFF4E6\], .bg-\[\#FFF3E0\], .bg-\[\#FFF8E1\] { background-color: var(--bg-warning) !important; }
+  .bg-\[\#F0FFF6\], .bg-\[\#F0FFF4\] { background-color: rgba(61,214,140,0.08) !important; }
+  header.bg-white { background-color: var(--bg-surface) !important; border-bottom-color: var(--border) !important; }
+  nav.bg-white    { background-color: var(--bg-surface) !important; border-top-color: var(--border) !important; }
+  .border-\[\#E5E8EB\], .border-\[\#F2F4F6\], .border-\[\#C9CDD2\] { border-color: var(--border) !important; }
   .divide-\[\#F2F4F6\] > * + * { border-color: var(--border) !important; }
-
   .text-\[\#191F28\] { color: var(--fg) !important; }
-  .text-\[\#6B7684\] { color: var(--fg-muted) !important; }
-  .text-\[\#8B95A1\] { color: var(--fg-muted) !important; }
-  .text-\[\#B0B8C1\] { color: var(--fg-disabled) !important; }
-
+  .text-\[\#4E5968\], .text-\[\#6B7684\] { color: var(--fg-muted) !important; }
+  .text-\[\#8B95A1\], .text-\[\#B0B8C1\], .text-\[\#C9CDD2\] { color: var(--fg-disabled) !important; }
+  .text-\[\#3182F6\], .text-\[\#1764ED\] { color: var(--fg-negative) !important; }
+  .text-\[\#FF9500\] { color: var(--fg-warning) !important; }
+  .text-\[\#2AC769\] { color: var(--fg-live) !important; }
   .text-up,   .text-\[\#F04452\] { color: var(--fg-positive) !important; }
-  .text-down, .text-\[\#1764ED\] { color: var(--fg-negative) !important; }
-
+  .text-down { color: var(--fg-negative) !important; }
   .badge-up   { background: var(--bg-positive) !important; color: var(--fg-positive) !important; }
   .badge-down { background: var(--bg-negative) !important; color: var(--fg-negative) !important; }
-  .badge-flat { background: var(--bg-alt) !important; color: var(--fg-muted) !important; }
-
+  .badge-flat, .badge-neutral { background: var(--bg-alt) !important; color: var(--fg-muted) !important; }
+  .badge-vol  { background: var(--bg-warning) !important; color: var(--fg-warning) !important; }
   .chip { background: var(--bg-alt) !important; border-color: var(--border) !important; color: var(--fg-muted) !important; }
   .chip.active { background: var(--fg) !important; border-color: var(--fg) !important; color: var(--bg-surface) !important; }
-
+  .stock-row { background: var(--bg-surface) !important; border-bottom-color: var(--border) !important; }
+  .stock-row:hover { background: var(--bg-hover) !important; }
+  .news-row:hover  { background: var(--bg-hover) !important; }
+  .news-row { border-bottom-color: var(--border) !important; }
+  .card { background: var(--bg-surface) !important; }
+  .sc   { background: var(--bg-surface) !important; }
   .hover\:bg-\[\#F9FAFB\]:hover, .hover\:bg-\[\#F2F4F6\]:hover { background-color: var(--bg-hover) !important; }
-  .active\:bg-\[\#F7F8FA\]:active { background-color: var(--bg-alt) !important; }
-
-  .bg-\[\#FFF8E1\] { background-color: rgba(255,149,0,0.1) !important; }
+  .active\:bg-\[\#F7F8FA\]:active, .active\:bg-\[\#F2F4F6\]:active { background-color: var(--bg-alt) !important; }
 }
+
+/* ─── 수동 토글(html.dark) 오버라이드 ───────────────────────── */
+html.dark .bg-white, html.dark [class*="bg-white"] { background-color: var(--bg-surface) !important; }
+html.dark .bg-\[\#F8F9FA\], html.dark .bg-\[\#F2F4F6\], html.dark .bg-\[\#FAFBFC\], html.dark .bg-\[\#F7F8FA\] { background-color: var(--bg-alt) !important; }
+html.dark .bg-\[\#FFF0F1\], html.dark .bg-\[\#FFF0F0\], html.dark .bg-\[\#FFD6D9\], html.dark .bg-\[\#FFD0D4\] { background-color: var(--bg-positive) !important; }
+html.dark .bg-\[\#EDF4FF\], html.dark .bg-\[\#F4F8FF\], html.dark .bg-\[\#F0F4FF\] { background-color: var(--bg-negative) !important; }
+html.dark .bg-\[\#FFF4E6\], html.dark .bg-\[\#FFF3E0\], html.dark .bg-\[\#FFF8E1\] { background-color: var(--bg-warning) !important; }
+html.dark .bg-\[\#F0FFF6\], html.dark .bg-\[\#F0FFF4\] { background-color: rgba(61,214,140,0.08) !important; }
+html.dark header.bg-white { background-color: var(--bg-surface) !important; border-bottom-color: var(--border) !important; }
+html.dark nav.bg-white    { background-color: var(--bg-surface) !important; border-top-color: var(--border) !important; }
+html.dark .border-\[\#E5E8EB\], html.dark .border-\[\#F2F4F6\], html.dark .border-\[\#C9CDD2\] { border-color: var(--border) !important; }
+html.dark .divide-\[\#F2F4F6\] > * + * { border-color: var(--border) !important; }
+html.dark .text-\[\#191F28\] { color: var(--fg) !important; }
+html.dark .text-\[\#4E5968\], html.dark .text-\[\#6B7684\] { color: var(--fg-muted) !important; }
+html.dark .text-\[\#8B95A1\], html.dark .text-\[\#B0B8C1\], html.dark .text-\[\#C9CDD2\] { color: var(--fg-disabled) !important; }
+html.dark .text-\[\#3182F6\], html.dark .text-\[\#1764ED\] { color: var(--fg-negative) !important; }
+html.dark .text-\[\#FF9500\] { color: var(--fg-warning) !important; }
+html.dark .text-\[\#2AC769\] { color: var(--fg-live) !important; }
+html.dark .text-up,   html.dark .text-\[\#F04452\] { color: var(--fg-positive) !important; }
+html.dark .text-down { color: var(--fg-negative) !important; }
+html.dark .badge-up   { background: var(--bg-positive) !important; color: var(--fg-positive) !important; }
+html.dark .badge-down { background: var(--bg-negative) !important; color: var(--fg-negative) !important; }
+html.dark .badge-flat, html.dark .badge-neutral { background: var(--bg-alt) !important; color: var(--fg-muted) !important; }
+html.dark .badge-vol  { background: var(--bg-warning) !important; color: var(--fg-warning) !important; }
+html.dark .chip { background: var(--bg-alt) !important; border-color: var(--border) !important; color: var(--fg-muted) !important; }
+html.dark .chip.active { background: var(--fg) !important; border-color: var(--fg) !important; color: var(--bg-surface) !important; }
+html.dark .stock-row { background: var(--bg-surface) !important; border-bottom-color: var(--border) !important; }
+html.dark .stock-row:hover { background: var(--bg-hover) !important; }
+html.dark .news-row:hover  { background: var(--bg-hover) !important; }
+html.dark .news-row { border-bottom-color: var(--border) !important; }
+html.dark .card { background: var(--bg-surface) !important; }
+html.dark .sc   { background: var(--bg-surface) !important; }
+html.dark .hover\:bg-\[\#F9FAFB\]:hover, html.dark .hover\:bg-\[\#F2F4F6\]:hover { background-color: var(--bg-hover) !important; }
+html.dark .active\:bg-\[\#F7F8FA\]:active, html.dark .active\:bg-\[\#F2F4F6\]:active { background-color: var(--bg-alt) !important; }


### PR DESCRIPTION
## 변경 내용

헤더 토글 버튼으로 다크모드를 수동 전환. 새로고침 후에도 유지.

## 구현

**`src/hooks/useDarkMode.js`** (신규)
- localStorage 저장 → 새로고침 후 유지
- 수동 설정 없을 때 `prefers-color-scheme` 자동 감지
- `html.dark` 클래스 직접 제어

**`src/styles/tokens.css`**
- `html.dark` 클래스 기반 오버라이드 추가 (시스템 미디어쿼리와 병행 지원)
- 누락 hex 커버리지 추가: `#FF9500` `#2AC769` `#4E5968` `#C9CDD2` `#3182F6`
- 배경 색상 확장: `#FFF0F1` `#EDF4FF` `#FFF4E6` `#F0FFF6` 등
- `color-scheme: dark` 힌트 → 스크롤바/인풋 브라우저 기본 UI에 다크 테마 적용

**`src/components/Header.jsx`**
- 달(🌙)/해(☀️) SVG 토글 버튼 추가 (새로고침 버튼 좌측)

**`src/App.jsx`**
- `useDarkMode` 훅 연결 → Header에 `dark` / `onDarkToggle` 전달

## 완료 기준

- [x] 헤더 토글 클릭 → 다크모드 전환
- [x] 새로고침 후 상태 유지 (localStorage)
- [x] 시스템 다크모드 자동 감지 (수동 설정 없을 때)
- [x] 빌드 통과 ✅

Closes #167

---
🤖 Generated by Claude Code [claude-sonnet-4-6]