### PR TITLE
feat: 국장 뉴스 RSS 소스 확장 — 이데일리·머니투데이·뉴스핌 추가

### DIFF
--- a/api/rss.js
+++ b/api/rss.js
@@ -21,6 +21,9 @@ const ALLOWED_DOMAINS = [
   // 한국 금융 뉴스 직접 RSS
   'www.yna.co.kr',
   'www.blockmedia.co.kr',
+  'www.edaily.co.kr',
+  'news.mt.co.kr',
+  'www.newspim.com',
   // 미국 주식 뉴스 직접 RSS
   'finance.yahoo.com',
   'feeds.content.dowjones.io',

--- a/src/api/news.js
+++ b/src/api/news.js
@@ -383,7 +383,7 @@ const KR_STOCK_NEWS_QUERIES = [
   },
 ];
 
-// [국장] 한국 금융 직접 RSS 피드 — 한경, 매경, 연합뉴스 경제, 블록미디어
+// [국장] 한국 금융 직접 RSS 피드 — 한경, 매경, 연합뉴스 경제, 블록미디어, 이데일리, 머니투데이, 뉴스핌
 const KR_DIRECT_RSS_FEEDS = [
   {
     url: 'https://www.hankyung.com/feed/all-news',
@@ -400,6 +400,18 @@ const KR_DIRECT_RSS_FEEDS = [
   {
     url: 'https://www.blockmedia.co.kr/feed',
     source: '블록미디어',
+  },
+  {
+    url: 'https://www.edaily.co.kr/rss/rssnews.asp',
+    source: '이데일리',
+  },
+  {
+    url: 'https://news.mt.co.kr/rss/rss.xml',
+    source: '머니투데이',
+  },
+  {
+    url: 'https://www.newspim.com/rss/rss.xml',
+    source: '뉴스핌',
   },
 ];
 


### PR DESCRIPTION
## 변경 내용

국장 직접 RSS 소스 4개 → 7개 확장으로 뉴스 커버리지 개선.

## 추가 소스

| 매체 | URL |
|------|-----|
| 이데일리 | edaily.co.kr/rss/rssnews.asp |
| 머니투데이 | news.mt.co.kr/rss/rss.xml |
| 뉴스핌 | newspim.com/rss/rss.xml |

## 변경 파일

- `src/api/news.js` — `KR_DIRECT_RSS_FEEDS` 3개 소스 추가
- `api/rss.js` — `ALLOWED_DOMAINS` 3개 도메인 추가 (SSRF 방어 유지)

Closes #169

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 한국 금융 뉴스의 세 가지 새로운 RSS 소스 추가 (이데일리, 머니투데이, 뉴스핌)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->