### PR TITLE
fix: 뉴스 클릭 시 관련종목 품질 개선 — newsTopicMap 섹터 매핑 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,6 +51,7 @@ export default function App() {
   const [loading, setLoading]           = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);
   const [selectedNews, setSelectedNews] = useState(null);
+  const [newsContext, setNewsContext]   = useState(null); // 뉴스에서 종목 클릭 시 뉴스 맥락 전달
   const [searchOpen, setSearchOpen]     = useState(false);
   const [notifBanner, setNotifBanner]   = useState(() => {
     const perm = getNotificationPermission();
@@ -199,10 +200,17 @@ export default function App() {
     return () => window.removeEventListener('popstate', onPop);
   }, [searchOpen, selectedNews, selectedItem]);
 
+  // 뉴스에서 종목 클릭 — 뉴스 맥락 함께 전달
+  const handleNewsRelatedClick = useCallback((item) => {
+    setNewsContext(selectedNews);
+    setSelectedItem(item);
+  }, [selectedNews]);
+
   // X 버튼 close 핸들러 — history entry도 함께 소비
   const closeSelectedItem = useCallback(() => {
     closingViaUI.current = true;
     setSelectedItem(null);
+    setNewsContext(null);
     history.back();
   }, []);
   const closeSelectedNews = useCallback(() => {
@@ -301,10 +309,10 @@ export default function App() {
       </div>
 
       {selectedItem && (
-        <ChartSidePanel item={selectedItem} krwRate={krwRate} onClose={closeSelectedItem} onRelatedClick={setSelectedItem} allData={allData} />
+        <ChartSidePanel item={selectedItem} krwRate={krwRate} onClose={closeSelectedItem} onRelatedClick={(item) => { setNewsContext(null); setSelectedItem(item); }} allData={allData} newsContext={newsContext} />
       )}
       {selectedNews && (
-        <NewsSidePanel news={selectedNews} allData={allData} krwRate={krwRate} onClose={closeSelectedNews} onRelatedClick={setSelectedItem} onNewsClick={setSelectedNews} />
+        <NewsSidePanel news={selectedNews} allData={allData} krwRate={krwRate} onClose={closeSelectedNews} onRelatedClick={handleNewsRelatedClick} onNewsClick={setSelectedNews} />
       )}
       {searchOpen && (
         <GlobalSearch krStocks={krStocks} usStocks={usStocks} coins={coins} etfs={etfItems} krwRate={krwRate} onSelect={setSelectedItem} onNewsClick={setSelectedNews} onClose={closeSearch} />

--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -26,6 +26,7 @@ import { fetchCandles, PERIOD_CONFIG } from '../api/chart';
 import { fetchInvestorDataSafe, fetchInvestorTrendSafe, formatNetAmt } from '../api/investor';
 import { useStockAndRelatedNews, useStockDirectNews } from '../hooks/useNewsQuery';
 import { findRelatedItems } from '../data/relatedAssets';
+import { detectNewsSectors, findStocksBySectors } from '../utils/newsTopicMap';
 
 // ─── 로고 URL + 아바타 색상 (home/utils.js 통합본 사용) ──────
 import { getLogoUrls, getAvatarBg as colorFor } from './home/utils';
@@ -542,7 +543,7 @@ function InvestorFlowEnhanced({ symbol }) {
 }
 
 // ─── 메인 패널 ──────────────────────────────────────────────────
-export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelatedClick, allData = {} }) {
+export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelatedClick, allData = {}, newsContext = null }) {
   const [period,    setPeriod]    = useState('5분');
   const [candles,   setCandles]   = useState([]);
   const [chartLoading, setChartLoading] = useState(false);
@@ -550,7 +551,19 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
   const [showMoreNews, setShowMoreNews] = useState(false); // "더 보기" 상태
   const [isFav, setIsFav]         = useState(false);       // 관심 종목 토글 (UI 전용)
 
+  // 뉴스 맥락 기반 관련종목 — newsContext가 있으면 키워드→섹터→종목 추출
+  const newsBasedItems = useMemo(() => {
+    if (!newsContext) return [];
+    const text = `${newsContext.title || ''} ${newsContext.description || newsContext.summary || ''}`;
+    const sectors = detectNewsSectors(text);
+    if (!sectors.length) return [];
+    const { krStocks = [], usStocks = [], coins = [] } = allData;
+    const allItems = [...krStocks, ...usStocks, ...coins];
+    return findStocksBySectors(sectors, allItems, 5);
+  }, [newsContext, allData]);
+
   // 연관 종목 — relatedAssets 매핑 기반, allData에서 현재 가격 조회 (뉴스 훅보다 먼저)
+  // newsContext가 있으면 뉴스 기반 관련종목을 앞에 합산 (중복 제거)
   const relatedItems = useMemo(() => {
     if (!item) return [];
     const { krStocks = [], usStocks = [], coins = [], etfs = [] } = allData;
@@ -560,8 +573,28 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
     for (const e of etfs)     dataMap[e.symbol] = e;
     for (const c of coins)    dataMap[c.symbol?.toUpperCase()] = c;
     const sym = item.symbol?.toUpperCase() || item.id?.toUpperCase() || '';
-    return findRelatedItems(sym, dataMap, 8); // 최대 8개
-  }, [item?.symbol, item?.name, allData]);
+    const assetBased = findRelatedItems(sym, dataMap, 8); // 최대 8개
+
+    // 뉴스 기반 관련종목이 있으면 앞에 합산
+    if (!newsBasedItems.length) return assetBased;
+    const seenKeys = new Set();
+    const merged = [];
+    // 뉴스 기반 종목 먼저 (현재 보고 있는 종목 제외)
+    for (const stock of newsBasedItems) {
+      const key = stock.symbol?.toUpperCase() || stock.id?.toUpperCase() || '';
+      if (key === sym || seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      merged.push({ ticker: stock.symbol || stock.id, item: stock, type: stock.market || 'news', reason: '뉴스 관련' });
+    }
+    // 기존 relatedAssets 기반 종목 추가 (중복 제거)
+    for (const rel of assetBased) {
+      const key = rel.ticker?.toUpperCase() || '';
+      if (seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      merged.push(rel);
+    }
+    return merged.slice(0, 10);
+  }, [item?.symbol, item?.name, allData, newsBasedItems]);
 
   // 종목 키워드 + 관련종목 기반 관련 뉴스 — 주 종목 → 관련종목 순으로 합산
   const newsMarket = item?.id ? 'COIN' : item?.market === 'kr' ? 'KR' : 'US';
@@ -907,7 +940,7 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
               {nonEtfItems.length > 0 && (
                 <>
                   <div className="text-[11px] font-semibold text-[#B0B8C1] uppercase tracking-wide mb-2">
-                    연관 종목
+                    {newsBasedItems.length > 0 ? '이 뉴스 관련 종목' : '연관 종목'}
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     {nonEtfItems.map(({ ticker, item: rel, type, reason: _reason }) => {
@@ -924,6 +957,8 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
                       // 타입별 배지
                       const typeBadge = type === 'coin'
                         ? { label: '코인', bg: '#FFF3E0', color: '#E65100' }
+                        : type === 'news' || type === 'kr' || type === 'us'
+                        ? { label: type === 'news' ? '뉴스' : '주식', bg: type === 'news' ? '#E8F5E9' : '#F2F4F6', color: type === 'news' ? '#2E7D32' : '#4E5968' }
                         : type === 'stock' || type === 'sector'
                         ? { label: '주식', bg: '#F2F4F6', color: '#4E5968' }
                         : null;


### PR DESCRIPTION
## Summary
- **뉴스에서 종목 클릭 시** `newsContext`를 `ChartSidePanel`에 전달하여 뉴스 키워드 → 섹터 → 관련종목 매핑
- `detectNewsSectors` / `findStocksBySectors` (기존 `newsTopicMap.js`)를 활용하여 뉴스 맥락 기반 관련종목을 기존 `relatedAssets` 앞에 합산 (중복 제거)
- 뉴스 기반 관련종목이 있으면 섹션 제목을 "이 뉴스 관련 종목"으로 변경

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/App.jsx` | `newsContext` 상태 추가, `handleNewsRelatedClick` 콜백, `NewsSidePanel` → `ChartSidePanel` 뉴스 맥락 전달 |
| `src/components/ChartSidePanel.jsx` | `newsContext` prop 수신, `newsBasedItems` useMemo, `relatedItems` 합산 로직, 섹션 제목 분기, typeBadge 확장 |

## Test plan
- [ ] 뉴스 패널에서 종목 클릭 → ChartSidePanel에 "이 뉴스 관련 종목" 섹션 표시 확인
- [ ] 반도체 뉴스 → 반도체/IT 섹터 종목이 관련종목 상단에 표시되는지 확인
- [ ] 일반 종목 클릭 (뉴스 경유 아님) → 기존 "연관 종목" 제목 유지 확인
- [ ] ChartSidePanel 내 연관 종목 클릭 시 newsContext 초기화 확인
- [ ] `npm run build` 성공 확인 (현재 origin/main CDS 의존성 이슈 별도 PR #186으로 해결 예정)

Closes #173

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 뉴스에서 파생된 관련 종목을 차트 패널에 표시합니다.
  * 뉴스 기반 관련 항목과 자산 기반 관련 항목의 표시 방식을 개선했습니다.
  * 뉴스 컨텍스트에서 접근할 때 관련 항목 헤더와 배지 스타일이 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->