### PR TITLE
chore: Vercel 자동 배포 Canceled 버그 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,9 @@
   "rewrites": [
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ],
-  "ignoreCommand": "[ \"$VERCEL_ENV\" != \"production\" ]"
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
 }


### PR DESCRIPTION
ignoreCommand가 Git 트리거 배포 시 Production 빌드까지 취소하는 문제 수정.
git.deploymentEnabled으로 main 브랜치만 배포하도록 변경.

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Main 브랜치에서의 배포 구성이 업데이트되었습니다. 배포 자동화 설정이 개선되어 배포 프로세스가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->