### PR TITLE
fix: 주목할 종목 휴장 시 국장/미장 마감 데이터 함께 표시

### DIFF
--- a/src/components/home/NotableMoversSection.jsx
+++ b/src/components/home/NotableMoversSection.jsx
@@ -143,8 +143,7 @@ export default function NotableMoversSection({ allItems = [], recentNews = [], k
     if (!allItems.length) return [];
 
     // 시장 상태 확인 — 휴장 시장도 포함하되 _isClosed 플래그로 구분
-    const krOpen = getKoreanMarketStatus().status === 'open';
-    const usOpen = getUsMarketStatus().status === 'open';
+    // krOpen/usOpen은 컴포넌트 본문에서 전달받아 의존성 배열에 포함
     const activeItems = allItems.map(item => {
       if (item._market === 'KR' && !krOpen) return { ...item, _isClosed: true };
       if (item._market === 'US' && !usOpen) return { ...item, _isClosed: true };
@@ -201,25 +200,28 @@ export default function NotableMoversSection({ allItems = [], recentNews = [], k
       .filter(i => i._totalScore >= 3)
       .sort((a, b) => b._totalScore - a._totalScore)
       .slice(0, 7);
-  }, [allItems, recentNews]);
+  }, [allItems, recentNews, krOpen, usOpen]);
 
   // 최소 2개 보장 — 점수 부족하면 변동폭 기준 fallback
   const displayed = useMemo(() => {
     if (notables.length >= 2) return notables;
+    // fallback도 _isClosed 플래그 부여 (휴장 종목 오인 방지)
     const fallback = [...allItems]
       .sort((a, b) => Math.abs(getPct(b)) - Math.abs(getPct(a)))
       .slice(0, 2)
       .map(i => {
+        const isClosed = (i._market === 'KR' && !krOpen) || (i._market === 'US' && !usOpen);
         const relatedNews = findRelatedNews(i, recentNews);
         return {
           ...i,
+          _isClosed: isClosed,
           _totalScore: 0, _newsCount: 0, _volRank: 999,
           _newsTitle: relatedNews?.title || null,
           _newsSource: relatedNews?.source || null,
         };
       });
     return fallback;
-  }, [notables, allItems, recentNews]);
+  }, [notables, allItems, recentNews, krOpen, usOpen]);
 
   if (!displayed.length) return null;
 


### PR DESCRIPTION
## 변경 내용

주말/휴장 시 국장·미장 종목이 `activeItems`에서 완전히 제외되어 코인만 표시되던 문제 수정.

### 핵심 변경

- `filter` → `map` 전환: 휴장 시장 종목을 제거하지 않고 `_isClosed: true` 플래그 부여
- `MKT_BADGE`에 `KR_CLOSED` / `US_CLOSED` 추가 (회색 계열 "국내 마감" / "미장 마감")
- 휴장 종목 점수 -2 패널티 → 라이브 종목 자연 상위 노출
- 섹션 헤더에 "마감 포함" 배지 (휴장 시장 있을 때만)
- fallback 경로에도 `_isClosed` 플래그 적용

## 독립 리뷰 결과

### code-reviewer (Claude)
- [채택] CRITICAL: useMemo 내 `krOpen`/`usOpen` 중복 호출 제거 + 의존성 배열 추가 → 수정 완료
- [채택] HIGH: fallback 경로 `_isClosed` 플래그 누락 → 수정 완료

### Codex gate (OpenAI)
- DECISION: PASS
- [P2] 프리마켓/애프터마켓도 `_isClosed`로 처리되어 실제 움직이는 가격이 "마감" 배지로 표시될 수 있음 → 향후 개선 항목으로 백로그 등록 예정 (현재 국장은 프리마켓 없음, 미장 애프터마켓 거래량 낮아 영향 제한적)

Closes #216

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경사항

* **개선사항**
  * 마감된 시장(한국, 미국) 항목의 표시 방식이 개선되었습니다.
  * 마감된 시장의 항목들이 "마감 포함" 인디케이터와 함께 명확하게 표시됩니다.
  * 시장 개장 상태에 따른 UI 인디케이터가 추가되었습니다.
  * 주목할 만한 움직임 목록의 순위 지정이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->