### PR TITLE
fix: 한투 fallback 주말 종목코드 노출 버그 수정 (정적 이름 맵)

### DIFF
--- a/api/cron/update-kr.js
+++ b/api/cron/update-kr.js
@@ -103,12 +103,8 @@ async function fetchHantooFallback() {
   if (!token) return null;
 
   // 주요 종목만 조회 (전종목 불가 — 한투는 개별 API)
-  const majorSymbols = [
-    '005930', '000660', '035420', '035720', '051910',
-    '006400', '068270', '028260', '105560', '055550',
-    '003670', '096770', '034730', '032830', '012330',
-    '066570', '003550', '015760', '017670', '316140',
-  ];
+  // HANTOO_NAME_MAP에서 파생 — 단일 소스, 종목 추가·삭제 시 맵만 수정
+  const majorSymbols = Object.keys(HANTOO_NAME_MAP);
 
   const results = await Promise.allSettled(
     majorSymbols.map(async (symbol) => {


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude)
크리티컬 없음. MEDIUM 1건 채택 — hts_kor_isnm 공백 문자열 방어 .trim() 추가

### Codex gate (OpenAI)
- PASS

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 주식의 한국어 이름 표시 정확성 개선 — 누락되거나 비어 있는 한국어 종목명이 있을 경우 신뢰할 수 있는 대체명과 우회 로직을 적용해 표시 오류를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->