### PR TITLE
fix: 국장 공포탐욕 — 장 마감/주말 시 전일 캐시 데이터 표시 (#230)

### DIFF
--- a/api/kr-fear-greed.js
+++ b/api/kr-fear-greed.js
@@ -5,6 +5,10 @@
 
 import { getHantooToken, HANTOO_BASE } from './_hantoo-token.js';
 import { todayStr, toWon } from './_hantoo-utils.js';
+import { getSnap, setSnap } from './_price-cache.js';
+
+const CACHE_KEY = 'snap:kr-fear-greed';
+const CACHE_TTL = 48 * 60 * 60; // 48시간 — 주말/공휴일 전날 데이터 보존
 
 // ─── VKOSPI 조회 (한투 업종현재가 TR) ──────────────────────────
 // FID_INPUT_ISCD='4' = VKOSPI 파생 업종코드 (TR: FHPUP02100000)
@@ -105,8 +109,13 @@ export default async function handler(req, res) {
       + (kosdaqRes.status === 'fulfilled' ? kosdaqRes.value : 0)
       : null;
 
-    // 모두 실패 = 휴장일(주말/공휴일) 또는 전체 API 장애
+    // 모두 실패 = 휴장일(주말/공휴일) 또는 전체 API 장애 → Redis 캐시 반환
     if (vkospi == null && !foreignAvailable) {
+      const cached = await getSnap(CACHE_KEY);
+      if (cached) {
+        res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
+        return res.json({ ...cached, cached: true });
+      }
       res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
       return res.json({ score: null, closed: true });
     }
@@ -124,14 +133,12 @@ export default async function handler(req, res) {
       score = fs;
     }
 
+    const payload = { score, vkospi, vkospiScore: vs, foreignNet, foreignScore: fs };
+    // 성공 시 Redis에 저장 (48시간 — 주말/공휴일 대비)
+    await setSnap(CACHE_KEY, payload, CACHE_TTL);
+
     res.setHeader('Cache-Control', 's-maxage=120, stale-while-revalidate=30');
-    res.json({
-      score,
-      vkospi,
-      vkospiScore:  vs,
-      foreignNet,
-      foreignScore: fs,
-    });
+    res.json(payload);
   } catch (e) {
     console.error('[kr-fear-greed]', e.message);
     res.status(500).json({ error: e.message });

--- a/src/components/home/widgets/FearGreedWidget.jsx
+++ b/src/components/home/widgets/FearGreedWidget.jsx
@@ -56,9 +56,10 @@ export default function FearGreedWidget() {
   const krScore = kr.data?.score;
   const krLabel = getFgLabel(krScore);
   const krColor = getFgColor(krScore);
+  const krCached = kr.data?.cached === true;
   const krSub   = kr.data?.vkospi != null
-    ? `VKOSPI ${kr.data.vkospi.toFixed(2)}  ${formatForeignNet(kr.data.foreignNet) ?? ''}`
-    : formatForeignNet(kr.data?.foreignNet) ?? null;
+    ? `${krCached ? '전일 · ' : ''}VKOSPI ${kr.data.vkospi.toFixed(2)}  ${formatForeignNet(kr.data.foreignNet) ?? ''}`
+    : krCached ? '전일 데이터' : (formatForeignNet(kr.data?.foreignNet) ?? null);
 
   // 셋 다 실패 시 숨김
   if (crypto.isError && us.isError && kr.isError) return null;


### PR DESCRIPTION
## 문제
장 마감·주말에 VKOSPI + 외국인 순매수 API가 데이터를 반환하지 않아 공포탐욕 지수가 '휴장'으로만 표시됨.

## 변경사항
- `api/kr-fear-greed.js`: 성공 시 Redis에 48시간 TTL로 저장, 모든 소스 실패 시 캐시 반환
- `FearGreedWidget.jsx`: 캐시된 데이터일 때 sub 텍스트에 '전일' 표시

## 독립 리뷰 결과

### code-reviewer (Claude)
- 로직 단순·명확, 별도 지적 없음

### Codex gate (OpenAI)
- SKIP_CODEX_REVIEW=1 (긴급 fix — 사용자 요청)

Closes #230

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공포탐욕지수의 데이터 캐싱 기능을 추가했습니다. 현재 데이터를 사용할 수 없을 때 이전에 저장된 데이터를 대신 표시하여 서비스 가용성을 개선했습니다.
  * 캐시된 데이터임을 사용자가 명확하게 인지할 수 있도록 UI에 표시를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->