### PR TITLE
fix: 뉴스 링크 window.open 강제 — PWA 앱 이탈 방지 (#234)

### DIFF
--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -1113,7 +1113,8 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
                     href={n.link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block px-4 py-2.5 hover:bg-[#FAFBFC] border-b border-[#F2F4F6] last:border-0 transition-colors"
+                    onClick={e => { e.preventDefault(); e.stopPropagation(); if (n.link) window.open(n.link, '_blank', 'noopener,noreferrer'); }}
+                    className="block px-4 py-2.5 hover:bg-[#FAFBFC] border-b border-[#F2F4F6] last:border-0 transition-colors cursor-pointer"
                   >
                     {/* 메타 행: 시간 + 시그널 라벨 */}
                     <div className="flex items-center gap-1.5 mb-0.5">

--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -378,7 +378,8 @@ const InsightCard = memo(function InsightCard({ mover, news, onMoverClick }) {
       href={news.link}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex-shrink-0 w-[260px] block rounded-xl border p-3 hover:opacity-90 transition-opacity"
+      onClick={e => { e.preventDefault(); e.stopPropagation(); if (news.link) window.open(news.link, '_blank', 'noopener,noreferrer'); }}
+      className="flex-shrink-0 w-[260px] block rounded-xl border p-3 hover:opacity-90 transition-opacity cursor-pointer"
       style={{ background: bgColor, borderColor }}
     >
       <div className="flex items-center gap-1.5 mb-2">

--- a/src/components/NewsSidePanel.jsx
+++ b/src/components/NewsSidePanel.jsx
@@ -410,7 +410,8 @@ export default function NewsSidePanel({ news, allData, krwRate, onClose, onRelat
               href={news.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center justify-center gap-1.5 w-full py-2.5 rounded-xl border border-[#E5E8EB] text-[13px] font-medium text-[#4E5968] hover:bg-[#F7F8FA] transition-colors"
+              onClick={e => { e.preventDefault(); e.stopPropagation(); if (news.link) window.open(news.link, '_blank', 'noopener,noreferrer'); }}
+              className="flex items-center justify-center gap-1.5 w-full py-2.5 rounded-xl border border-[#E5E8EB] text-[13px] font-medium text-[#4E5968] hover:bg-[#F7F8FA] transition-colors cursor-pointer"
             >
               원문 보기
               <span className="text-[11px]">↗</span>


### PR DESCRIPTION
## 문제
PWA/모바일 환경에서 뉴스 링크 클릭 시 target=_blank가 무시되고 현재 창에서 외부 사이트로 이동(앱 이탈)

## 변경사항
- ChartSidePanel 관련뉴스, NewsSidePanel 원문보기, HomeDashboard 뉴스카드 모두 `window.open(url, '_blank', 'noopener,noreferrer')` + `e.preventDefault()` + `e.stopPropagation()` 적용

Closes #234

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 여러 컴포넌트의 링크 상호작용 방식을 개선하여 더욱 안정적인 네비게이션 처리로 변경
  * 관련 뉴스 및 카드 항목에 마우스 커서 포인터 스타일 추가로 클릭 가능성 시각화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->