### PR TITLE
fix: 5분봉 빈 차트 + 타임프레임 버튼 줄바꿈 수정 (#236)

### DIFF
--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -29,7 +29,7 @@ function SimpleTabs({ tabs, activeTab, onChange }) {
         <button
           key={tab.id}
           onClick={() => onChange(tab.id)}
-          className={`flex-1 text-[12px] font-medium py-1 px-2 rounded-md transition-colors ${
+          className={`flex-1 whitespace-nowrap text-[12px] font-medium py-1 px-1.5 rounded-md transition-colors ${
             activeTab === tab.id
               ? 'bg-white text-[#191F28] shadow-sm'
               : 'text-[#8B95A1] hover:text-[#191F28]'
@@ -723,6 +723,14 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
     fetchCandles(item, period)
       .then(data => setCandles(data))
       .catch(() => {
+        const isIntraday = PERIOD_CONFIG[period]?.isIntraday ?? false;
+        // intraday 실패 시 — 일별 fallback으로 전환해도 포맷 불일치 발생 → 빈 차트 대신 '일' 데이터 재요청
+        if (isIntraday) {
+          fetchCandles(item, '일')
+            .then(data => setCandles(data))
+            .catch(() => setCandles([]));
+          return;
+        }
         const spark = item.sparkline ?? [];
         const today = new Date();
         const fake  = spark.map((close, i) => {


### PR DESCRIPTION
## 수정 내용
1. **5분봉 빈 차트**: intraday fetch 실패 시 sparkline fallback이 `'YYYY-MM-DD'` 문자열을 사용하는데, intraday 차트는 Unix seconds를 기대 → 포맷 불일치로 빈 화면. 이제 일봉(`fetchCandles(item, '일')`)으로 re-fetch하여 최소한의 데이터 표시
2. **버튼 줄바꿈**: `whitespace-nowrap` + `px-1.5` 추가

Closes #236

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 업데이트 사항

* **Style**
  - 탭 버튼의 패딩을 조정하여 레이블 표시를 개선했습니다.

* **Bug Fixes**
  - 차트 데이터 로드 실패 시 일봉 데이터로 자동 재시도하는 기능을 추가하여 더욱 안정적인 차트 표시를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->