### PR TITLE
fix: ETF 가격 Yahoo v7 제거 → v8 병렬 직행 (#239)

### DIFF
--- a/api/etf-prices.js
+++ b/api/etf-prices.js
@@ -21,48 +21,9 @@ export default async function handler(req) {
     });
   }
 
-  const results = [];
-
-  // 1) Yahoo v7 배치 (커버리지 우수, ETF 최적)
-  try {
-    const url = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${symbols.join(',')}`;
-    const res = await fetch(url, {
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible)', 'Accept': 'application/json' },
-      signal: AbortSignal.timeout(7000),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      const quotes = data?.quoteResponse?.result ?? [];
-      for (const q of quotes) {
-        if (q.regularMarketPrice > 0) {
-          const price     = q.regularMarketPrice;
-          const change    = q.regularMarketChange ?? 0;
-          // Yahoo가 소형 ETF에서 regularMarketChangePercent를 null로 반환하는 경우
-          // change/prevClose로 직접 계산 (prevClose = price - change)
-          const prevClose = price - change;
-          const changePct = q.regularMarketChangePercent != null
-            ? q.regularMarketChangePercent
-            : (change !== 0 && prevClose > 0
-                ? parseFloat((change / prevClose * 100).toFixed(2))
-                : 0);
-          results.push({
-            symbol:    q.symbol,
-            price,
-            change:    parseFloat(change.toFixed(2)),
-            changePct: parseFloat(changePct.toFixed(2)),
-            volume:    q.regularMarketVolume ?? 0,
-          });
-        }
-      }
-    }
-  } catch {}
-
-  // 2) Yahoo v8 개별 chart fallback — v7에서 누락된 소형 ETF 항상 실행
-  const found = new Set(results.map(r => r.symbol));
-  const missing = symbols.filter(s => !found.has(s));
-
+  // Yahoo v8 chart — 병렬 배치 (v7는 2026-03 Unauthorized 차단으로 제거)
   const settled = await Promise.allSettled(
-    missing.map(async (symbol) => {
+    symbols.map(async (symbol) => {
       const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=5d`;
       const res = await fetch(url, {
         headers: { 'User-Agent': 'Mozilla/5.0 (compatible)', 'Accept': 'application/json' },
@@ -96,9 +57,7 @@ export default async function handler(req) {
     })
   );
 
-  for (const r of settled) {
-    if (r.status === 'fulfilled') results.push(r.value);
-  }
+  const results = settled.filter(r => r.status === 'fulfilled').map(r => r.value);
 
   return new Response(JSON.stringify({ results }), {
     headers: {


### PR DESCRIPTION
## 문제
Yahoo Finance v7 API가 Unauthorized(401) 차단 → ETF 가격 전체 미표시

## 변경사항
- `api/etf-prices.js`: v7 배치 호출 제거 (7초 낭비 해소)
- v8 chart 엔드포인트로 30개 병렬 직행

Closes #239

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **개선 사항**
  * ETF 가격 데이터 조회 로직을 개선하여 시스템의 안정성과 효율성을 향상시켰습니다. 기존의 복잡한 처리 방식을 간소화하고 통합함으로써 더욱 효율적인 가격 정보 제공이 가능해졌습니다. 이를 통해 사용자에게 더욱 빠르고 신뢰할 수 있는 ETF 가격 정보를 제공할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->