### PR TITLE
fix: 뉴스 링크 div+window.open 교체 — PWA 이탈 완전 차단 (#241)

### DIFF
--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -1125,12 +1125,12 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
               visibleNews.map((n, i) => {
                 const signal = extractSignalLabel(n.title);
                 return (
-                  <a
+                  <div
                     key={n.id || i}
-                    href={n.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={e => { e.preventDefault(); e.stopPropagation(); if (n.link) window.open(n.link, '_blank', 'noopener,noreferrer'); }}
+                    role="button"
+                    tabIndex={0}
+                    onClick={e => { e.stopPropagation(); if (n.link) window.open(n.link, '_blank', 'noopener,noreferrer'); }}
+                    onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); if (n.link) window.open(n.link, '_blank', 'noopener,noreferrer'); } }}
                     className="block px-4 py-2.5 hover:bg-[#FAFBFC] border-b border-[#F2F4F6] last:border-0 transition-colors cursor-pointer"
                   >
                     {/* 메타 행: 시간 + 시그널 라벨 */}
@@ -1150,7 +1150,7 @@ export default function ChartSidePanel({ item, krwRate = 1466, onClose, onRelate
                     <div className="text-[12px] text-[#191F28] font-medium leading-snug line-clamp-2">
                       {n.title}
                     </div>
-                  </a>
+                  </div>
                 );
               })
             )}

--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -374,17 +374,17 @@ const InsightCard = memo(function InsightCard({ mover, news, onMoverClick }) {
   const borderColor = isUp ? '#FFE8E8' : '#DCE9FF';
 
   return (
-    <a
-      href={news.link}
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={e => { e.preventDefault(); e.stopPropagation(); if (news.link) window.open(news.link, '_blank', 'noopener,noreferrer'); }}
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => { if (news.link) window.open(news.link, '_blank', 'noopener,noreferrer'); }}
+      onKeyDown={e => { if (e.key === 'Enter' && news.link) window.open(news.link, '_blank', 'noopener,noreferrer'); }}
       className="flex-shrink-0 w-[260px] block rounded-xl border p-3 hover:opacity-90 transition-opacity cursor-pointer"
       style={{ background: bgColor, borderColor }}
     >
       <div className="flex items-center gap-1.5 mb-2">
         <button
-          onClick={e => { e.preventDefault(); onMoverClick?.(mover); }}
+          onClick={e => { e.stopPropagation(); onMoverClick?.(mover); }}
           className="flex items-center gap-1 hover:opacity-75 flex-shrink-0"
         >
           <span className="text-[12px] font-bold text-[#191F28]">{mover.name}</span>
@@ -412,7 +412,7 @@ const InsightCard = memo(function InsightCard({ mover, news, onMoverClick }) {
       <div className="text-[12px] text-[#4E5968] leading-snug line-clamp-2">
         {news.title}
       </div>
-    </a>
+    </div>
   );
 });
 

--- a/src/components/NewsSidePanel.jsx
+++ b/src/components/NewsSidePanel.jsx
@@ -406,16 +406,16 @@ export default function NewsSidePanel({ news, allData, krwRate, onClose, onRelat
         {/* 하단: 원문 보기 */}
         {news.link && (
           <div className="flex-shrink-0 px-4 py-4 border-t border-[#F2F4F6]">
-            <a
-              href={news.link}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={e => { e.preventDefault(); e.stopPropagation(); if (news.link) window.open(news.link, '_blank', 'noopener,noreferrer'); }}
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={e => { e.stopPropagation(); if (news.link) window.open(news.link, '_blank', 'noopener,noreferrer'); }}
+              onKeyDown={e => { if (e.key === 'Enter' && news.link) window.open(news.link, '_blank', 'noopener,noreferrer'); }}
               className="flex items-center justify-center gap-1.5 w-full py-2.5 rounded-xl border border-[#E5E8EB] text-[13px] font-medium text-[#4E5968] hover:bg-[#F7F8FA] transition-colors cursor-pointer"
             >
               원문 보기
               <span className="text-[11px]">↗</span>
-            </a>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## 문제
PR #235 window.open 추가 후에도 이탈 계속. `<a>` 태그의 기본 navigate가 PWA 환경에서 window.open과 별개로 트리거됨.

## 변경사항
- ChartSidePanel 관련뉴스, NewsSidePanel 원문보기, HomeDashboard 뉴스카드 전체를 `<a>` → `<div role="button">` + `window.open` 으로 교체
- HomeDashboard 내부 종목명 버튼에 `stopPropagation` 추가

Closes #241

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **향상 사항**
  * 뉴스 기사 및 카드 요소의 키보드 접근성을 개선했습니다. 이제 Tab 키와 Enter 키를 사용하여 항목을 활성화하고 새 탭에서 열 수 있습니다.
  * 네비게이션 동작이 더욱 안정적으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->