### PR TITLE
fix: 뉴스 속보 태그 오탐 전면 수정 — 광범위 키워드 정리 및 속보 뱃지 제거

### DIFF
--- a/src/components/BreakingNewsPanel.jsx
+++ b/src/components/BreakingNewsPanel.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { useNewsAutoRefetch, useCategoryNewsQuery } from '../hooks/useNewsQuery';
 import WhalePanel from './WhalePanel';
 import { subscribeLatestWhale } from '../state/whaleBus';
-import { extractNewsSignals, getNewsImpact, isBreakingNews, getNewsImpactType } from '../utils/newsSignal';
+import { extractNewsSignals, getNewsImpact, getNewsImpactType, getNewsImportanceScore } from '../utils/newsSignal';
 import { clusterNews } from '../utils/newsCluster';
 
 // ─── 종목 태그 추출 — 뉴스 제목에서 주요 종목명 감지 ──────────
@@ -51,22 +51,13 @@ function cleanDesc(raw) {
     .replace(/\s+/g, ' ').trim();
 }
 
-// 속보 시간 감쇠 — 1시간 경과 시 "주요"로 전환
-function getBreakingBadge(title, pubDate) {
-  if (!isBreakingNews(title, pubDate)) return null;
-  const ageMs = Date.now() - new Date(pubDate).getTime();
-  if (ageMs > 3600000) return { label: '주요', bg: '#FFF4E6', color: '#FF9500' }; // 1시간+ → 주요
-  return { label: '속보', bg: '#FFF0F1', color: '#F04452' };
-}
 
 function NewsItem({ item, onNewsClick, relatedCount = 0 }) {
   const cat = CAT_COLOR[item.category] || { bg: '#F2F4F6', color: '#6B7684', label: 'NEWS' };
   // 시그널 태그 추출 — pubDate 전달하여 속보(🔴 속보) 자동 감지, 최대 2개
-  const signals = extractNewsSignals(item.title, item.pubDate);
+  const signals = extractNewsSignals(item.title);
   const impact = getNewsImpact(item.title);
-  const impactType = getNewsImpactType(item.title, item.pubDate);
-  // 속보 시간 감쇠 배지
-  const breakingBadge = getBreakingBadge(item.title, item.pubDate);
+  const impactType = getNewsImpactType(item.title);
   // 뉴스 제목에서 종목 태그 추출
   const stockTags = extractStockTags(item.title);
   // RSS description 1줄 미리보기
@@ -78,14 +69,6 @@ function NewsItem({ item, onNewsClick, relatedCount = 0 }) {
       className="block px-4 py-3 border-b border-[#F2F4F6] hover:bg-[#FAFBFC] transition-colors cursor-pointer"
     >
       <div className="flex items-center gap-1.5 mb-1.5">
-        {breakingBadge && (
-          <span
-            className="text-[10px] font-bold px-1.5 py-0.5 rounded flex-shrink-0"
-            style={{ background: breakingBadge.bg, color: breakingBadge.color }}
-          >
-            {breakingBadge.label}
-          </span>
-        )}
         <span
           className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold flex-shrink-0"
           style={{ background: cat.bg, color: cat.color }}
@@ -166,17 +149,16 @@ function useTabNews(activeTab) {
   return allQuery;
 }
 
-// 속보(긴급성+중요도+시장영향도)를 상단에 핀 — 속보 내에서도 최신순, 일반 뉴스도 최신순
-function sortWithBreakingFirst(items) {
-  const getMs = (i) => {
-    const ms = i.pubDate ? new Date(i.pubDate).getTime() : 0;
-    return isNaN(ms) ? 0 : ms;
-  };
-  const breaking = items.filter(i => isBreakingNews(i.title, i.pubDate))
-    .sort((a, b) => getMs(b) - getMs(a));
-  const normal = items.filter(i => !isBreakingNews(i.title, i.pubDate))
-    .sort((a, b) => getMs(b) - getMs(a));
-  return [...breaking, ...normal];
+// 중요도 점수 내림차순 정렬 — 동점이면 최신순
+function sortByImportance(items) {
+  return [...items].sort((a, b) => {
+    const scoreA = getNewsImportanceScore(a);
+    const scoreB = getNewsImportanceScore(b);
+    if (scoreB !== scoreA) return scoreB - scoreA;
+    const msA = a.pubDate ? new Date(a.pubDate).getTime() : 0;
+    const msB = b.pubDate ? new Date(b.pubDate).getTime() : 0;
+    return (isNaN(msB) ? 0 : msB) - (isNaN(msA) ? 0 : msA);
+  });
 }
 
 // 금액 포맷 (고래 핀용)
@@ -231,7 +213,7 @@ export default function BreakingNewsPanel({ coins = [], onItemClick, onNewsClick
   }, [activeTab]);
 
   // 전체 탭은 최대 30건, 카테고리 탭은 전체 — 속보는 상단 핀 정렬
-  const sortedNews = sortWithBreakingFirst(activeTab === 'all' ? rawNews.slice(0, 30) : rawNews);
+  const sortedNews = sortByImportance(activeTab === 'all' ? rawNews.slice(0, 30) : rawNews);
 
   // 클러스터링 적용 — 중복 뉴스 제거, 대표 1건 + 관련 보도 N건 접기
   const clusteredNews = useMemo(() => {

--- a/src/components/BreakingNewsPanel.jsx
+++ b/src/components/BreakingNewsPanel.jsx
@@ -54,7 +54,7 @@ function cleanDesc(raw) {
 
 function NewsItem({ item, onNewsClick, relatedCount = 0 }) {
   const cat = CAT_COLOR[item.category] || { bg: '#F2F4F6', color: '#6B7684', label: 'NEWS' };
-  // 시그널 태그 추출 — pubDate 전달하여 속보(🔴 속보) 자동 감지, 최대 2개
+  // 시그널 태그 추출, 최대 2개
   const signals = extractNewsSignals(item.title);
   const impact = getNewsImpact(item.title);
   const impactType = getNewsImpactType(item.title);

--- a/src/components/home/MarketTimeline.jsx
+++ b/src/components/home/MarketTimeline.jsx
@@ -2,7 +2,7 @@
 import { useMemo } from 'react';
 import { useSignals } from '../../hooks/useSignals';
 import { useAllNewsQuery } from '../../hooks/useNewsQuery';
-import { isBreakingNews } from '../../utils/newsSignal';
+import { getNewsImportanceScore } from '../../utils/newsSignal';
 
 // 타임라인 아이템 타입별 스타일
 const TYPE_STYLE = {
@@ -25,7 +25,7 @@ function buildTimelineItems(signals, breakingNews) {
     });
   }
 
-  // 속보 뉴스
+  // 주요 뉴스
   for (const news of breakingNews) {
     items.push({
       time: new Date(news.pubDate).getTime(),
@@ -42,7 +42,7 @@ export default function MarketTimeline() {
   const signals = useSignals();
   const { data: allNews = [] } = useAllNewsQuery();
 
-  // 오늘 속보 뉴스 필터
+  // 오늘 주요 뉴스 필터 (중요도 점수 5점 이상)
   const breakingNews = useMemo(() => {
     const todayStart = new Date();
     todayStart.setHours(0, 0, 0, 0);
@@ -50,7 +50,7 @@ export default function MarketTimeline() {
       if (!n.pubDate) return false;
       try {
         const pubMs = new Date(n.pubDate).getTime();
-        return pubMs >= todayStart.getTime() && isBreakingNews(n.title, n.pubDate);
+        return pubMs >= todayStart.getTime() && getNewsImportanceScore(n) >= 5;
       } catch { return false; }
     });
   }, [allNews]);

--- a/src/components/home/TopNewsSection.jsx
+++ b/src/components/home/TopNewsSection.jsx
@@ -11,7 +11,7 @@ function computeTimeAgo(pubDate) {
   if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
   return `${Math.floor(diff / 86400)}일 전`;
 }
-import { extractNewsSignals, getNewsImpact, getNewsImportanceScore, isBreakingNews } from '../../utils/newsSignal';
+import { extractNewsSignals, getNewsImpact, getNewsImportanceScore } from '../../utils/newsSignal';
 import { buildStockKeywords, matchesKeywords, getMatchConfidence } from '../../utils/newsAlias';
 
 const CAT_BADGE = {
@@ -98,7 +98,7 @@ export default function TopNewsSection({ allNews = [], onNewsClick, onItemClick,
 
     return recent
       .map(n => {
-        const signals = extractNewsSignals(n.title, n.pubDate);
+        const signals = extractNewsSignals(n.title);
         const impact = getNewsImpact(n.title);
         const importanceScore = getNewsImportanceScore(n);
         // 종목 실제 움직임 점수 (연결된 종목의 변동폭 합산)
@@ -135,8 +135,6 @@ export default function TopNewsSection({ allNews = [], onNewsClick, onItemClick,
 
       {topNews.map((item, i) => {
         const cat = CAT_BADGE[item.category] || { bg: '#F2F4F6', color: '#8B95A1', label: 'NEWS' };
-        const isBreaking = isBreakingNews(item.title, item.pubDate);
-
         return (
           <div
             key={item.id || i}
@@ -148,11 +146,6 @@ export default function TopNewsSection({ allNews = [], onNewsClick, onItemClick,
             </span>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5 mb-1 flex-wrap">
-                {isBreaking && (
-                  <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-[#FFF0F1] text-[#F04452] flex-shrink-0">
-                    속보
-                  </span>
-                )}
                 <span
                   className="text-[10px] font-bold px-1.5 py-0.5 rounded flex-shrink-0"
                   style={{ background: cat.bg, color: cat.color }}

--- a/src/utils/newsSignal.js
+++ b/src/utils/newsSignal.js
@@ -6,8 +6,8 @@ const URGENT_KW = [
   'fomc','연준 금리','기준금리 결정','금리인상','금리인하','긴급 금리',
   '파산','도산','부도','법정관리','상장폐지','거래정지','서킷브레이커',
   '쇼크','폭락','붕괴','시장 충격','블랙스완',
-  '전쟁 선포','지진','테러','핵',
-  '강제청산','마진콜','런','bank run',
+  '전쟁 선포','지진','테러','핵무기','핵실험','핵공격','핵미사일',
+  '강제청산','마진콜','뱅크런','bank run',
 ];
 
 // 30분 이내 + 매칭 시 속보
@@ -95,19 +95,13 @@ export function getNewsImportanceScore(item) {
 
 /**
  * getNewsImpactType(title)
- * 뉴스 영향 유형 뱃지 반환 — 거시/실적/공시/속보
+ * 뉴스 영향 유형 뱃지 반환 — 거시/실적/공시
  * @param {string} title
- * @param {string|null} pubDate
  * @returns {{ label: string, bg: string, color: string } | null}
  */
-export function getNewsImpactType(title, pubDate) {
+export function getNewsImpactType(title) {
   if (!title) return null;
   const lower = title.toLowerCase();
-
-  // 속보 판단
-  if (isBreakingNews(title, pubDate)) {
-    return { label: '⚡ 속보', bg: '#FFF0F1', color: '#F04452' };
-  }
 
   // 거시 (금리/환율/GDP 등)
   const macroKw = ['금리','환율','gdp','cpi','ppi','fomc','연준','fed','금통위','실업률','고용','인플레이션','pce','nfp','소비자물가','생산자물가'];
@@ -122,7 +116,7 @@ export function getNewsImpactType(title, pubDate) {
   }
 
   // 공시 (상장/M&A/증자 등)
-  const disclosureKw = ['상장','ipo','인수','합병','m&a','증자','분할','공시','매각','지분','자사주','상장폐지'];
+  const disclosureKw = ['상장','ipo','인수합병','m&a','증자','분할','공시','매각','지분','자사주','상장폐지'];
   if (disclosureKw.some(kw => lower.includes(kw))) {
     return { label: '🏢 공시', bg: '#F5F3FF', color: '#8B5CF6' };
   }
@@ -131,11 +125,8 @@ export function getNewsImpactType(title, pubDate) {
 }
 
 // priority: 낮을수록 먼저 표시 (0=최우선)
-// timeCheck: true면 isBreakingNews로 판단
+// 속보 태그 제거 — 키워드 기반 속보 판단은 오탐률이 높아 카테고리 태그로 대체
 export const NEWS_SIGNALS = [
-  // 속보 (isBreakingNews 기반 — 긴급성+중요도+시장영향도 조합)
-  { tag: '🔴 속보',   keywords: [],      bg: '#FFF0F1', color: '#F04452', priority: 0, timeCheck: true },
-
   // 실적/재무
   { tag: '💰 실적',   keywords: ['영업이익','매출','순이익','실적','어닝','earnings','revenue','EPS','어닝서프라이즈','어닝쇼크','잠정실적'], bg: '#F0FFF6', color: '#2AC769', priority: 1 },
 
@@ -145,20 +136,20 @@ export const NEWS_SIGNALS = [
   // 상승/급등
   { tag: '🚀 급등',   keywords: ['급등','신고가','상한가','돌파','급상승','폭등','52주 신고가','역대최고'], bg: '#FFF4E6', color: '#FF6B00', priority: 2 },
 
-  // 하락/위험
-  { tag: '⚠️ 급락',   keywords: ['급락','하한가','폭락','급하락','위기','붕괴','쇼크','충격','공포'], bg: '#FFF0F1', color: '#F04452', priority: 2 },
+  // 하락/위험 — '위기','충격' 제거 (오탐: "위기 극복", "충격 고백")
+  { tag: '⚠️ 급락',   keywords: ['급락','하한가','폭락','급하락','붕괴','쇼크','공포'], bg: '#FFF0F1', color: '#F04452', priority: 2 },
 
-  // 인수합병/공시
-  { tag: '📋 공시',   keywords: ['인수','합병','M&A','공시','지분','자사주','유상증자','분할','합병비율','상장','IPO','상장폐지'], bg: '#F5F3FF', color: '#8B5CF6', priority: 2 },
+  // 인수합병/공시 — '인수','합병','상장' → 복합어로 교체 (오탐: "인수위", "상장사")
+  { tag: '📋 공시',   keywords: ['인수합병','M&A','공시','지분매각','자사주','유상증자','분할','상장폐지','신규상장','IPO'], bg: '#F5F3FF', color: '#8B5CF6', priority: 2 },
 
   // 고래/기관
   { tag: '🐋 대량',   keywords: ['기관매수','외국인매수','대량매수','순매수','블록딜','대형매도','외국인순매수'], bg: '#F0F9FF', color: '#0EA5E9', priority: 2 },
 
-  // 규제/정책
-  { tag: '🏛 정책',   keywords: ['규제','정책','법안','제재','승인','FDA','SEC','금감원','공정위','관세','무역'], bg: '#FFFBEB', color: '#D97706', priority: 3 },
+  // 규제/정책 — '승인' 제거 (오탐: "대출 승인"), '정책' → 복합어
+  { tag: '🏛 정책',   keywords: ['규제','법안','제재','FDA승인','SEC','금감원','공정위','관세','무역정책','통화정책','재정정책'], bg: '#FFFBEB', color: '#D97706', priority: 3 },
 
-  // 기술/신제품
-  { tag: '⚡ 신제품',  keywords: ['출시','공개','발표','개발','특허','계약','수주','신제품','업그레이드'], bg: '#F0FFF6', color: '#059669', priority: 3 },
+  // 기술/신제품 — '발표','공개','개발','계약' 제거 (너무 광범위)
+  { tag: '⚡ 신제품',  keywords: ['신제품 출시','제품 출시','특허','수주','업그레이드','신기술'], bg: '#F0FFF6', color: '#059669', priority: 3 },
 ];
 
 // ─── 감성 점수 5단계 키워드 분류 ────────────────────────────
@@ -177,16 +168,19 @@ const STRONG_NEGATIVE_KW = [
 ];
 const MILD_POSITIVE_KW = [
   '목표가 상향', '투자의견 상향', '매수 추천', '신사업', '제휴',
-  '계약 체결', '수주', '특허', '승인', '상향', '호실적',
-  '성장', '확대', '기대', '반등', '회복',
+  '계약 체결', '수주', '특허', '호실적',
+  '반등', '회복',
   'bullish', 'outperform', 'buy rating', 'rally',
 ];
+// '성장','확대','기대' 제거 — "성장 둔화", "적자 확대", "기대 이하" 등 부정 맥락 오분류
+// '상향','승인' 제거 — 단독 사용 시 맥락 불명확
 const MILD_NEGATIVE_KW = [
   '목표가 하향', '투자의견 하향', '매도 추천', '소송', '경쟁 심화',
-  '실적 하회', '하향', '둔화', '우려', '리스크', '하락',
+  '실적 하회', '둔화', '우려', '리스크',
   '감소', '축소', '부진', '위축',
   'bearish', 'underperform', 'sell rating', 'decline',
 ];
+// '하향','하락' 제거 — "하향 안정", "하락 방어" 등 긍정 맥락 오분류
 
 /**
  * getNewsSentimentScore(title)
@@ -230,13 +224,15 @@ export function getSentimentStyle(score) {
 
 // ─── 호재/악재/중립 임팩트 분류 ─────────────────────────────
 const IMPACT_POSITIVE = [
-  '실적 개선','영업이익 증가','흑자전환','흑자','어닝서프라이즈','목표가 상향','상향','매수',
+  '실적 개선','영업이익 증가','흑자전환','흑자','어닝서프라이즈','목표가 상향',
   '급등','신고가','상한가','수주','계약 체결','수출 증가','증익','호실적','자사주 매입','배당 증가',
 ];
+// '상향','매수' 제거 — 단독 사용 시 맥락 불명확 ("상향 여부", "매수세 약화")
 const IMPACT_NEGATIVE = [
-  '적자','영업손실','어닝쇼크','목표가 하향','하향','매도','급락','하한가','부도','파산','상장폐지',
-  '리콜','제재','과징금','손실','위기','붕괴','감익','배당 삭감','대규모 매도','공매도',
+  '적자','영업손실','어닝쇼크','목표가 하향','급락','하한가','부도','파산','상장폐지',
+  '리콜','제재','과징금','붕괴','감익','배당 삭감','대규모 매도','공매도',
 ];
+// '하향','매도','손실','위기' 제거 — "하향 안정","매도 제한","손실 축소","위기 극복" 등 오분류
 
 /**
  * getNewsImpact(title)
@@ -255,33 +251,24 @@ export function getNewsImpact(title) {
   return { label: '⚪ 중립', bg: '#F2F4F6', color: '#8B95A1' };
 }
 
+// 사전 정렬된 시그널 (매 호출마다 정렬하지 않음)
+const SORTED_SIGNALS = [...NEWS_SIGNALS].sort((a, b) => a.priority - b.priority);
+
 /**
- * extractNewsSignals(title, pubDate?)
+ * extractNewsSignals(title)
  * 뉴스 제목에서 매칭되는 시그널 태그를 최대 2개 반환 (priority 낮은 순)
  * @param {string} title
- * @param {string|null} pubDate  - ISO 날짜 문자열 (속보 timeCheck용)
  * @returns {{ tag: string, color: string, bg: string }[]}
  */
-export function extractNewsSignals(title, pubDate) {
+export function extractNewsSignals(title) {
   if (!title) return [];
   const lower = title.toLowerCase();
 
-  // 속보 여부: 긴급성+중요도+시장영향도 조합 판단
-  const breaking = isBreakingNews(title, pubDate);
-
   const matched = [];
-  // priority 오름차순 정렬 후 최대 2개 추출
-  const sorted = [...NEWS_SIGNALS].sort((a, b) => a.priority - b.priority);
-
-  for (const sig of sorted) {
+  for (const sig of SORTED_SIGNALS) {
     if (matched.length >= 2) break;
-    if (sig.timeCheck) {
-      // 속보: isBreakingNews 함수로 판단
-      if (breaking) matched.push({ tag: sig.tag, color: sig.color, bg: sig.bg });
-    } else {
-      const hit = sig.keywords.some(kw => lower.includes(kw.toLowerCase()));
-      if (hit) matched.push({ tag: sig.tag, color: sig.color, bg: sig.bg });
-    }
+    const hit = sig.keywords.some(kw => lower.includes(kw.toLowerCase()));
+    if (hit) matched.push({ tag: sig.tag, color: sig.color, bg: sig.bg });
   }
   return matched;
 }

--- a/src/utils/newsSignal.js
+++ b/src/utils/newsSignal.js
@@ -10,10 +10,10 @@ const URGENT_KW = [
   '강제청산','마진콜','뱅크런','bank run',
 ];
 
-// 30분 이내 + 매칭 시 속보
+// 중요도 점수용 영향도 키워드 (getNewsImportanceScore에서 +3점)
 const IMPACT_BREAKING_KW = [
   '실적 발표','어닝 서프라이즈','어닝 쇼크','깜짝 실적',
-  '인수','합병','매각','상장','ipo','공모가',
+  '인수합병','매각','신규상장','ipo','공모가',
   '목표주가 상향','목표주가 하향','투자의견 변경',
   'cpi 발표','ppi 발표','gdp 발표','실업률 발표','nfp',
   '현물 etf 승인','비트코인 etf',
@@ -30,34 +30,6 @@ const TWO_HOURS = 2 * 3600000;
 const THIRTY_MIN = 1800000;
 const ONE_HOUR = 3600000;
 
-/**
- * isBreakingNews(title, pubDate)
- * 속보 여부 판단 — 시간 + 긴급성/중요도/시장영향도 조합
- * @param {string} title
- * @param {string|null} pubDate
- * @returns {boolean}
- */
-export function isBreakingNews(title, pubDate) {
-  if (!title || !pubDate) return false;
-  const pubMs = new Date(pubDate).getTime();
-  if (isNaN(pubMs)) return false;
-  const age = Date.now() - pubMs;
-  if (age < 0) return false;
-
-  const lower = title.toLowerCase();
-
-  // 2시간 이내 + 긴급 키워드 매칭
-  if (age < TWO_HOURS && URGENT_KW.some(kw => lower.includes(kw))) {
-    return true;
-  }
-
-  // 30분 이내 + 영향도 키워드 매칭
-  if (age < THIRTY_MIN && IMPACT_BREAKING_KW.some(kw => lower.includes(kw))) {
-    return true;
-  }
-
-  return false;
-}
 
 /**
  * getNewsImportanceScore(item)
@@ -116,7 +88,7 @@ export function getNewsImpactType(title) {
   }
 
   // 공시 (상장/M&A/증자 등)
-  const disclosureKw = ['상장','ipo','인수합병','m&a','증자','분할','공시','매각','지분','자사주','상장폐지'];
+  const disclosureKw = ['신규상장','ipo','인수합병','m&a','증자','분할','공시','매각','지분','자사주','상장폐지'];
   if (disclosureKw.some(kw => lower.includes(kw))) {
     return { label: '🏢 공시', bg: '#F5F3FF', color: '#8B5CF6' };
   }


### PR DESCRIPTION
## Summary
- '런','핵' 등 1~2글자 URGENT_KW가 includes() 부분 매칭으로 거의 모든 뉴스를 속보로 분류하던 버그 수정
- 속보 뱃지/태그 완전 제거 → 카테고리 태그(거시/실적/공시)로 대체
- NEWS_SIGNALS, 감성 분석, 임팩트 분류의 광범위 키워드 전면 정리
- 뉴스 정렬을 isBreakingNews 이분법 → getNewsImportanceScore 점수 기반으로 전환

## 독립 리뷰 결과

### code-reviewer (Claude)
- [채택] isBreakingNews dead export 제거
- [채택] IMPACT_BREAKING_KW '인수','합병','상장' → 복합어 교체
- [채택] getNewsImpactType disclosureKw '상장' → '신규상장'
- [채택] 속보 참조 주석 정리

### Codex gate (OpenAI)
- 실행 완료, 지적사항 없음 (PASS)

## Test plan
- [ ] 뉴스 패널에서 '속보' 뱃지가 더 이상 표시되지 않는지 확인
- [ ] 카테고리 태그(거시/실적/공시)가 정상 표시되는지 확인
- [ ] 시그널 태그(급등/급락/지표 등)가 적절한 뉴스에만 표시되는지 확인
- [ ] 타임라인에 중요도 높은 뉴스만 표시되는지 확인
- [ ] 홈 TopNewsSection 정상 렌더링 확인

Closes #248

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **뉴스 우선순위 시스템**
  * 속보 기반 우선순위에서 중요도 점수 기반 시스템으로 변경

* **UI 개선**
  * 뉴스 아이템의 속보 배지 제거
  * 뉴스 신호 분류 로직 개선으로 더 정확한 카테고리 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->